### PR TITLE
Adds "cheerio" demo

### DIFF
--- a/ssr/demo/cheerio/README.md
+++ b/ssr/demo/cheerio/README.md
@@ -4,7 +4,7 @@ This example demonstrates the use of
 [Cheerio](https://github.com/cheeriojs/cheerio) to apply jQuery-like
 transformations to a DOM, as an alternative to the
 [domutils](https://github.com/fb55/domutils)-style transformations of the
-build-in transformers.
+built-in transformers.
 
 Usage:
 

--- a/ssr/demo/cheerio/README.md
+++ b/ssr/demo/cheerio/README.md
@@ -1,0 +1,17 @@
+# amp-toolbox-ssr-cheerio-demo
+
+This example demonstrates the use of
+[Cheerio](https://github.com/cheeriojs/cheerio) to apply jQuery-like
+transformations to a DOM, as an alternative to the
+[domutils](https://github.com/fb55/domutils)-style transformations of the
+build-in transformers.
+
+Usage:
+
+```sh
+node index.js example.html
+```
+
+The output is transformed by some of built-in transformers, and the
+`CheerioTransformer` is used to: (1) prepend "SSR" to the `<title>`; and (2)
+enable the `amp-fx-parallax` experiment.

--- a/ssr/demo/cheerio/example.html
+++ b/ssr/demo/cheerio/example.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>Hello, AMPs</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  </head>
+  <body>
+    <h1>Welcome to the mobile web</h1>
+  </body>
+</html>

--- a/ssr/demo/cheerio/index.js
+++ b/ssr/demo/cheerio/index.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+'use strict';
+
+const fs = require('fs');
+
+const ssr = require('amp-toolbox-ssr');
+const cheerio = require('cheerio');
+
+if (process.argv.length !== 3 || !fs.existsSync(process.argv[2])) {
+  process.stderr.write([
+    'usage:',
+    process.argv[0],
+    process.argv[1],
+    'filename'
+  ].join(' '));
+  process.exit(1);
+}
+
+const FILENAME = process.argv[2];
+
+class CheerioTransformer {
+
+  /**
+   * More about tree's type: tree is a parse5
+   * [Document](http://inikulin.github.io/parse5/modules/ast.html#document),
+   * with the htmlparser2
+   * [TreeAdapter](http://inikulin.github.io/parse5/globals.html#treeadapters),
+   * which results in a tree that's mostly compatible with that of
+   * [htmlparser2](https://github.com/fb55/htmlparser2/). (Though note that
+   * TreeParser.js itself monkey-patches some additional methods.)
+   *
+   * More about params' type: this is the second argument of
+   * DomTransformer.transformHtml(), and is (probably) an object of key-value
+   * pairs.
+   *
+   * @param {parse5.AST.HtmlParser2.Document} tree a DOM tree
+   * @param {Object} params transformer options
+   */
+  transform(tree, params) {
+    const $ = cheerio.load(tree.root.children);
+    // Prepends "SSR" to the <title>
+    $('title').text('SSR: ' + $('title').text());
+    // Injects amp-fx-parallax component
+    $('head').append(
+      '<script async custom-element="amp-fx-parallax" src="https://cdn.ampproject.org/v0/amp-fx-parallax-0.1.js"></script>'
+    );
+    // Enables parallax scrolling
+    $('h1').attr('amp-fx-parallax', params.ampFxParallax);
+    // Enables the component
+    $('body').append([
+      '<script>',
+      'document.cookie="AMP_EXP=amp-fx-parallax;Path=/;Expires=Tue, 01-Jan-2036 08:00:01 GMT"',
+      '</script>'
+    ].join(''));
+    // See the docs for other methods:
+    // https://github.com/cheeriojs/cheerio/blob/master/Readme.md
+  }
+}
+
+ssr.setConfig({
+  transformers: [
+    new CheerioTransformer(),
+    'AddAmpLink',
+    'ServerSideRendering',
+    'RemoveAmpAttribute',
+    // needs to run after ServerSideRendering
+    'AmpBoilerplateTransformer',
+    // needs to run after ServerSideRendering
+    'ReorderHeadTransformer'
+  ]
+});
+
+console.log(ssr.transformHtml(
+  fs.readFileSync(FILENAME, 'utf8'),
+  {ampFxParallax: '1.7'}
+));
+

--- a/ssr/demo/cheerio/package-lock.json
+++ b/ssr/demo/cheerio/package-lock.json
@@ -1,0 +1,184 @@
+{
+  "name": "amp-toolbox-ssr-cheerio-demo",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
+      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA=="
+    },
+    "amp-toolbox-ssr": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/amp-toolbox-ssr/-/amp-toolbox-ssr-0.0.3.tgz",
+      "integrity": "sha512-jznhBFdFh2AZIZqVgrbIcmkvgJlAbUol/9W3jx6GC6hRwfeptcGKi7TKzCY8dKUkaKJoycbgBGy81XRgVrAZHg==",
+      "requires": {
+        "parse5": "3.0.3"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash": "4.17.4",
+        "parse5": "3.0.3"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "8.5.5"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    }
+  }
+}

--- a/ssr/demo/cheerio/package.json
+++ b/ssr/demo/cheerio/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "amp-toolbox-ssr-cheerio-demo",
+  "version": "0.0.1",
+  "description": "Transform document via Cheerio",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "AMPHTML team",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "amp-toolbox-ssr": "*",
+    "cheerio": "^1.0.0-rc.2"
+  }
+}


### PR DESCRIPTION
This example demonstrates the use of [Cheerio](https://github.com/cheeriojs/cheerio) to manipulate the DOM in a jQuery-like way, as an alternative to the [domutils](https://github.com/fb55/domutils)-style transformations of the built-in transformers.

e.g. `$('title').text('SSR: ' + $('title').text())` prepends `SSR` to the `<title>`.