### PR TITLE
Makes middleware compatible with Connect

### DIFF
--- a/ssr-express/spec/lib/AmpSsrMiddlewareSpec.js
+++ b/ssr-express/spec/lib/AmpSsrMiddlewareSpec.js
@@ -61,15 +61,15 @@ describe('Express Middleware', () => {
         });
     });
 
-    it('Skips Resource Requests', () => {
-      const staticResources = ['/image.jpg', '/image.svg', '/script.js', '/style.css'];
-      const runStaticTest = url => {
-        runMiddlewareForUrl(middleware, url)
-          .then(result => {
-            expect(result).toEqual('original');
-          });
-      };
-      staticResources.forEach(url => runStaticTest(url));
+    const runStaticTest = url => {
+      runMiddlewareForUrl(middleware, url)
+        .then(result => {
+          expect(result).toEqual('original');
+        });
+    };
+
+    ['/image.jpg', '/image.svg', '/script.js', '/style.css'].forEach(url => {
+      it(`Does not transform ${url}`, () => runStaticTest(url));
     });
 
     it('Applies transformation if req.accept method does not exist', () => {

--- a/ssr-express/spec/lib/AmpSsrMiddlewareSpec.js
+++ b/ssr-express/spec/lib/AmpSsrMiddlewareSpec.js
@@ -72,7 +72,7 @@ describe('Express Middleware', () => {
       staticResources.forEach(url => runStaticTest(url));
     });
 
-    it('Applies transformation is accept method does not exist', () => {
+    it('Applies transformation if req.accept method does not exist', () => {
       runMiddlewareForUrl(middleware, '/page.html', null)
         .then(result => {
           expect(result).toEqual('transformed: /page.html?amp=');

--- a/ssr-express/spec/lib/AmpSsrMiddlewareSpec.js
+++ b/ssr-express/spec/lib/AmpSsrMiddlewareSpec.js
@@ -24,14 +24,14 @@ class TestTransformer {
   }
 }
 
-function runMiddlewareForUrl(middleware, url, accepts = 'html') {
+function runMiddlewareForUrl(middleware, url, accepts = () => 'html') {
   return new Promise(resolve => {
     const mockResponse = new MockExpressResponse();
     const next = () => mockResponse.send('original');
     const mockRequest = new MockExpressRequest({
       url: url
     });
-    mockRequest.accepts = () => accepts;
+    mockRequest.accepts = accepts;
 
     const end = mockResponse.end;
     mockResponse.end = chunks => {
@@ -72,8 +72,15 @@ describe('Express Middleware', () => {
       staticResources.forEach(url => runStaticTest(url));
     });
 
+    it('Applies transformation is accept method does not exist', () => {
+      runMiddlewareForUrl(middleware, '/page.html', null)
+        .then(result => {
+          expect(result).toEqual('transformed: /page.html?amp=');
+        });
+    });
+
     it('Skips transformation if request does not accept HTML', () => {
-      runMiddlewareForUrl(middleware, '/page.html', '')
+      runMiddlewareForUrl(middleware, '/page.html', () => '')
         .then(result => {
           expect(result).toEqual('original');
         });


### PR DESCRIPTION
- Checking for static resources verifies existance of req.accepts
- Call res.write and res.end when transformation is finished,
  instead of calling res.send.
- Updated JSDoc

Change-Id: Ia6edf4e57c8779954b5173bc2664ef3d194e93aa