### PR TITLE
Optimise placement of Google Fonts preload

### DIFF
--- a/optimizer/lib/transformers/GoogleFontsPreconnect.js
+++ b/optimizer/lib/transformers/GoogleFontsPreconnect.js
@@ -34,6 +34,8 @@ class GoogleFontsPreconnect {
   transform(tree) {
     const html = tree.root.firstChildByTag('html');
     const head = html.firstChildByTag('head');
+    const referenceNode = this.getReferenceNode_(head);
+
     for (let node = head.firstChild; node !== null; node = node.nextSibling) {
       if (this.isGoogleFontsLinkNode_(node)) {
         // Preconnect to fonts.gstatic.com, where the final fonts are downloaded.
@@ -41,9 +43,22 @@ class GoogleFontsPreconnect {
         linkPreconnect.attribs.rel = 'preconnect';
         linkPreconnect.attribs.href = 'https://fonts.gstatic.com';
         linkPreconnect.attribs.crossorigin = '';
-        head.insertBefore(linkPreconnect, node);
+        head.insertBefore(linkPreconnect, referenceNode);
       }
     }
+  }
+
+  getReferenceNode_(head) {
+    const referenceNode = head.firstChildByTag('meta');
+
+    // Check if firstChild is meta charset and return nextSibling so that the preconnect is
+    // inserted after the meta charset tag.
+    if (referenceNode && referenceNode.tagName === 'meta' && referenceNode.attribs.charset) {
+      return referenceNode.nextSibling;
+    }
+
+    // Otherwise, the preconnect will be inserted before the 1st element in the head.
+    return head.firstChild;
   }
 
   isGoogleFontsLinkNode_(node) {

--- a/optimizer/spec/transformers/GoogleFontsPreconnect/adds_preconnect_after_meta_charset/expected_output.html
+++ b/optimizer/spec/transformers/GoogleFontsPreconnect/adds_preconnect_after_meta_charset/expected_output.html
@@ -1,5 +1,6 @@
 <html ⚡>
   <head>
+    <meta charset="utf-8">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
     <script async src=https://cdn.ampproject.org/v0.js></script>
     <script async custom-element=amp-experiment src=https://cdn.ampproject.org/v0/amp-experiment-0.1.js></script>

--- a/optimizer/spec/transformers/GoogleFontsPreconnect/adds_preconnect_after_meta_charset/input.html
+++ b/optimizer/spec/transformers/GoogleFontsPreconnect/adds_preconnect_after_meta_charset/input.html
@@ -1,13 +1,13 @@
 <html ⚡>
   <head>
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+    <meta charset="utf-8">
     <script async src=https://cdn.ampproject.org/v0.js></script>
     <script async custom-element=amp-experiment src=https://cdn.ampproject.org/v0/amp-experiment-0.1.js></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;
 -moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
     <noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>  
     <link href=https://example.com/favicon.ico rel=icon>
-    <link href="https://fonts.googleapis.com/css?family=Inconsolata|Montserrat" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Inconsolata|Montserrat" rel="stylesheet">    
   </head>
   <body>
     <amp-img src="/image.png"></amp-img>


### PR DESCRIPTION
- Move preload to the beginning of the head section, after the
  meta charset tag.
