### PR TITLE
Move Resource Hints to top

### DIFF
--- a/optimizer/lib/transformers/ReorderHeadTransformer.js
+++ b/optimizer/lib/transformers/ReorderHeadTransformer.js
@@ -27,6 +27,7 @@ class HeadNodes {
     this._metaOther = [];
     this._scriptRenderDelayingExtensions = [];
     this._scriptNonRenderDelayingExtensions = [];
+    this._resourceHintLinks = [];
     this._linkIcons = [];
     this._styleAmpCustom = null;
     this._linkStylesheetsBeforeAmpCustom = [];
@@ -59,6 +60,7 @@ class HeadNodes {
     head.appendChild(this._styleAmpRuntime);
     head.appendChild(this._linkStyleAmpRuntime);
     head.appendChild(this._metaCharset);
+    head.appendAll(this._resourceHintLinks);
     head.appendAll(this._metaOther);
     head.appendChild(this._scriptAmpEngine);
     head.appendAll(this._scriptRenderDelayingExtensions);
@@ -157,6 +159,15 @@ class HeadNodes {
       this._linkIcons.push(node);
       return;
     }
+
+    if (rel === 'preload' ||
+      rel === 'prefetch' ||
+      rel === 'dns-prefetch' ||
+      rel === 'preconnect') {
+      this._resourceHintLinks.push(node);
+      return;
+    }
+
     this._others.push(node);
   }
 

--- a/optimizer/spec/end-to-end/hello-world/expected_output.html
+++ b/optimizer/spec/end-to-end/hello-world/expected_output.html
@@ -2,6 +2,7 @@
 <html i-amphtml-layout="" i-amphtml-no-boilerplate="">
 <head><style amp-runtime>/* v0.css */</style>
   <meta charset="utf-8">
+  <link rel="preload" href="https://cdn.ampproject.org/v0/amp-mustache-0.1.js">      
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <link rel="preload" href="/amp/rtv/001515617716922/v0.js" as="script">
   <script async="" src="/amp/rtv/001515617716922/v0.js"></script>

--- a/optimizer/spec/end-to-end/hello-world/input.html
+++ b/optimizer/spec/end-to-end/hello-world/input.html
@@ -15,6 +15,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <link rel="preload" href="https://cdn.ampproject.org/v0/amp-mustache-0.1.js">
   <style amp-custom>
     h1 {
       margin: 16px;

--- a/optimizer/spec/transformers/ReorderHeadTransformer/optimize_move_resource_hints_top/expected_output.html
+++ b/optimizer/spec/transformers/ReorderHeadTransformer/optimize_move_resource_hints_top/expected_output.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="preload" href="/example.css">
+  <link rel="preconnect" href="/example.css">
+  <link rel="prefetch" href="/example.css">
+  <link rel="dns-prefetch" href="/example.css">  
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element=amp-audio src=https://cdn.ampproject.org/v0/amp-audio-0.1.js></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <link href=https://example.com/favicon.ico rel=icon>
+  <link rel="prerender" href="/example.html">  
+</head>
+<body></body>
+</html>

--- a/optimizer/spec/transformers/ReorderHeadTransformer/optimize_move_resource_hints_top/input.html
+++ b/optimizer/spec/transformers/ReorderHeadTransformer/optimize_move_resource_hints_top/input.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element=amp-audio src=https://cdn.ampproject.org/v0/amp-audio-0.1.js></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <link href=https://example.com/favicon.ico rel=icon>
+  <link rel="preload" href="/example.css">
+  <link rel="preconnect" href="/example.css">
+  <link rel="prefetch" href="/example.css">
+  <link rel="dns-prefetch" href="/example.css">
+  <link rel="prerender" href="/example.html">
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
- Update OptimizeHeaderTransformer to move existing `preload`,
  `preconnect`, `prefetch` and `dns-prefetch` to top of page.
  Since those hints are not render-blocking, they are just below
  the charset meta tag.
- Keeps `prerender` hints at the end of the head, as the process
  is resource heavy and benefit the next click, not the current
  page being rendered.

Change-Id: I9d104507bb561b7d23db6ec7b0da0b61bd1b2b03