### PR TITLE
Fixes runtime-css replacing > with &gt;

### DIFF
--- a/optimizer/lib/TreeParser.js
+++ b/optimizer/lib/TreeParser.js
@@ -113,6 +113,10 @@ Node.hasAttribute = function(attribute) {
   return attribute in this.attribs;
 };
 
+Node.insertText = function(text) {
+  htmlparser2.insertText(this, text);
+};
+
 /**
  * A DOM Tree
  */
@@ -140,22 +144,6 @@ class Tree {
       result.attribs = attribs;
     }
     return result;
-  }
-
-  /**
-   * Creates a new text node
-   *
-   * @param {string} value
-   * @returns {Node} new node
-   */
-  createTextNode(value) {
-    return Node.constructor({
-      type: 'text',
-      data: value,
-      parent: null,
-      prev: null,
-      next: null
-    });
   }
 }
 

--- a/optimizer/lib/transformers/AmpBoilerplateTransformer.js
+++ b/optimizer/lib/transformers/AmpBoilerplateTransformer.js
@@ -63,7 +63,7 @@ class AmpBoilerplateTransformer {
 
   _addStaticCss(tree, node, params) {
     if (params.ampRuntimeVersion && !params.linkCss) {
-      return this._inlineCss(tree, node, params.ampRuntimeVersion);
+      return this._inlineCss(node, params.ampRuntimeVersion);
     }
     this._linkCss(tree, node);
   }
@@ -77,12 +77,10 @@ class AmpBoilerplateTransformer {
     node.parent.insertBefore(cssStyleNode, node);
   }
 
-  _inlineCss(tree, node, version) {
+  _inlineCss(node, version) {
     const versionedV0CssUrl = appendRuntimeVersion(AMP_CACHE_HOST, version) + '/' + V0_CSS;
     return this.fetch_.get(versionedV0CssUrl)
-      .then(body => {
-        node.children.push(tree.createTextNode(body));
-      });
+      .then(body => node.insertText(body));
   }
 
   _stripStylesAndNoscript(head) {

--- a/optimizer/spec/lib/TreeParserSpec.js
+++ b/optimizer/spec/lib/TreeParserSpec.js
@@ -131,12 +131,6 @@ describe('Tree', () => {
       expect(element.attribs.myAttribute).toBe('hello');
     });
   });
-  describe('createTextNode', () => {
-    it('sets data', () => {
-      const textNode = tree.createTextNode('test');
-      expect(textNode.data).toBe('test');
-    });
-  });
   describe('appendChild', () => {
     let firstElement;
     let secondElement;


### PR DESCRIPTION
- Favors parse5 insertText method instead of using our own
  method to create a and insert a text node.
