### PR TITLE
Fix amp-runtime-version returning invalid version

### DIFF
--- a/runtime-version/lib/RuntimeVersion.js
+++ b/runtime-version/lib/RuntimeVersion.js
@@ -41,7 +41,7 @@ class RuntimeVersion {
     if (options.canary) {
       return this.fetchVersion_(CANARY_ENDPOINT, (data) => this.padVersionString(data[0]));
     }
-    return this.fetchVersion_(RELEASE_ENDPOINT, (data) => data.amp_runtime_version);
+    return this.fetchVersion_(RELEASE_ENDPOINT, (data) => data.ampRuntimeVersion);
   }
 
   /* PRIVATE */

--- a/runtime-version/package.json
+++ b/runtime-version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-toolbox-runtime-version",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AMP Runtime versions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- The production endpoint changed the version field in the returned
  JSON to `ampRuntimeVersion`. Updated the code to use that
  instead of the previous `amp_runtime_version`.

- Updated version to 0.2.1
