### PR TITLE
Insert hidden attribute when layout=nodisplay

### DIFF
--- a/optimizer/lib/transformers/ApplyLayout.js
+++ b/optimizer/lib/transformers/ApplyLayout.js
@@ -50,7 +50,7 @@ function apply(layout, width, height, node) {
   let styles = '';
   switch (layout) {
     case 'nodisplay':
-      styles = 'display:none;';
+      node.attribs.hidden = 'hidden';
       break;
     case 'fixed':
       styles = `width:${width.numeral}${width.unit};height:${height.numeral}${height.unit};`;

--- a/optimizer/spec/transformers/ServerSideRendering/transforms_layout_nodisplay/expected_output.html
+++ b/optimizer/spec/transformers/ServerSideRendering/transforms_layout_nodisplay/expected_output.html
@@ -6,7 +6,7 @@
     <amp-img
       layout=nodisplay
       class=i-amphtml-layout-nodisplay
-      style=display:none;
+      hidden=hidden
       i-amphtml-layout=nodisplay >
     </amp-img>
   </body>


### PR DESCRIPTION
Context: https://github.com/ampproject/amphtml/pull/18419

AMP Runtime now controls display:none toggling through the hidden attribute. This updates the SSR transform to inject the hidden attribute instead of an inline display:none style.

This must be merged **after** the next production promote. I'll comment when that happens.