### PR TITLE
amp-toolbox-cache-url: Specified files in package.json

### DIFF
--- a/cache-url/package.json
+++ b/cache-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-toolbox-cache-url",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Transform canonical URLs into AMP Cache URLs",
   "main": "dist/amp-toolbox-cache-url.cjs.js",
   "module": "dist/amp-toolbox-cache-url.esm.js",

--- a/cache-url/package.json
+++ b/cache-url/package.json
@@ -29,6 +29,12 @@
     "url": "https://github.com/ampproject/amp-toolbox/issues"
   },
   "homepage": "https://github.com/ampproject/amp-toolbox#readme",
+  "files": [
+    "dist",
+    "package.json",
+    "../LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "punycode": "^2.1.1",
     "url-parse": "^1.4.3"


### PR DESCRIPTION
Noticed on unpkg, which is a service that acts as a mirror and CDN of npm, we weren't uploading built files to the module: 

https://unpkg.com/amp-toolbox-cache-url@1.0.0/

This includes the [files key to our package.json](https://docs.npmjs.com/files/package.json#files), that way we include the build output.

**Please note:** This required that we build the module before we publish to npm. Perhaps we should make a deploy script @sebastianbenz ?