### PR TITLE
Update Cache API 1.0

### DIFF
--- a/cache-url/package.json
+++ b/cache-url/package.json
@@ -1,12 +1,13 @@
 {
   "name": "amp-toolbox-cache-url",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Transform canonical URLs into AMP Cache URLs",
   "main": "dist/amp-toolbox-cache-url.cjs.js",
   "module": "dist/amp-toolbox-cache-url.esm.js",
   "browser": "dist/amp-toolbox-cache-url.umd.js",
   "scripts": {
     "build": "npx rollup -c",
+    "prepublish": "npm run build",
     "serve": "npx rollup -c -w",
     "test": "npm-run-all build test-node test-browser lint",
     "test-node": "npx jasmine --config=jasmine.json",

--- a/update-cache/package-lock.json
+++ b/update-cache/package-lock.json
@@ -66,12 +66,12 @@
       }
     },
     "amp-toolbox-cache-url": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/amp-toolbox-cache-url/-/amp-toolbox-cache-url-0.1.0.tgz",
-      "integrity": "sha512-fT7pXZDx15dAVgZB6jP1WHltR+SMOPpoaG/qhOuuUPH8lFTFivQ2+owyLYKAfwkui6Ia3lYqKeTH7UB0VQXZzg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/amp-toolbox-cache-url/-/amp-toolbox-cache-url-1.0.2.tgz",
+      "integrity": "sha512-/aiHsZb2POiQrpa1QJ0s7od8XWRMDfmpUsigApDb3hlUZCAzBoukN1bnbdAR0frmeLCWNmZmIgOwcTXwimDxbA==",
       "requires": {
-        "mime-types": "^2.1.18",
-        "punycode": "^2.1.0"
+        "punycode": "^2.1.1",
+        "url-parse": "^1.4.3"
       }
     },
     "amp-toolbox-core": {
@@ -728,19 +728,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-    },
-    "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-      "requires": {
-        "mime-db": "~1.33.0"
-      }
-    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -900,6 +887,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+    },
     "regexpp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
@@ -915,6 +907,11 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -1098,6 +1095,15 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "which": {

--- a/update-cache/package.json
+++ b/update-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-toolbox-update-cache",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Implements the AMP update-cache API, as described at https://developers.google.com/amp/cache/update-cache ",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/ampproject/amp-toolbox#readme",
   "dependencies": {
     "amp-toolbox-cache-list": "^0.1.0",
-    "amp-toolbox-cache-url": "^0.1.0",
+    "amp-toolbox-cache-url": "^1.0.2",
     "jsrsasign": "^8.0.12"
   },
   "devDependencies": {

--- a/update-cache/spec/UpdateCacheUrlProviderSpec.js
+++ b/update-cache/spec/UpdateCacheUrlProviderSpec.js
@@ -28,18 +28,22 @@ describe('UpdateCacheUrlProvider', () => {
   const updateCacheUrl = new UpdateCacheUrlProvider(signature, caches);
 
   describe('calculateFromCacheUrl', () => {
-    it('Generates the correct signature', () => {
+    it('Generates the correct signature', (done) => {
       const timestamp = 1;
-      const result = updateCacheUrl.calculateFromCacheUrl('https://test.com', timestamp);
-      const expected =
+      updateCacheUrl.calculateFromCacheUrl('https://test.com', timestamp).then((result) => {
+        const expected =
           'https://test.com/update-cache/?amp_action=flush&amp_ts=1&amp_url_signature=RESULT_SIGNATURE';
-      expect(result).toBe(expected);
+        expect(result).toBe(expected);
+        done();
+      });
     });
 
-    it('Generates signature with default timestamp', () => {
-      const result = updateCacheUrl.calculateFromCacheUrl('https://test.com');
-      const regex = /amp_ts=\d+/;
-      expect(result).toMatch(regex);
+    it('Generates signature with default timestamp', (done) => {
+      updateCacheUrl.calculateFromCacheUrl('https://test.com').then((result) => {
+        const regex = /amp_ts=\d+/;
+        expect(result).toMatch(regex);
+        done();
+      });
     });
   });
 
@@ -49,6 +53,8 @@ describe('UpdateCacheUrlProvider', () => {
       updateCacheUrl.calculateFromOriginUrl('https://test.com', timestamp)
           .then((result) => {
             expect(result.length).toBe(2);
+            expect(result[0].cacheId).toBe('test');
+            expect(result[1].cacheId).toBe('example');
           });
     });
   });


### PR DESCRIPTION
* uses Cache URL 1.0
* migrates API to promises as cache URL is now promise based
* adds prepublish script for cache URL package