### PR TITLE
Fix bug with unsupported width=auto

### DIFF
--- a/packages/optimizer/lib/ParseLayout.js
+++ b/packages/optimizer/lib/ParseLayout.js
@@ -17,12 +17,12 @@
 
 const VALID_UNITS = ['px', 'em', 'rem', 'vh', 'vw', 'vmin', 'vmax'];
 const AMP_LAYOUTS = ['nodisplay', 'fixed', 'responsive', 'fixed-height',
-  'fill', 'container', 'flex-item'];
+  'fill', 'container', 'flex-item', 'fluid', 'intrinsic'];
 const SIZE_DEFINED_LAYOUTS = ['fixed', 'fixed-height', 'responsive', 'fill', 'flex-item'];
-const CSS_LENGTH_ONE_PX = cssLength('1', false);
-const CSS_LENGTH_AUTO = cssLength('auto', true);
-const CSS_LENGTH_FOURTY_FOUR_PX = cssLength('44px', false);
-const CSS_LENGTH_SIXTY_PX = cssLength('60px', false);
+const CSS_LENGTH_ONE_PX = cssLength('1', false, false);
+const CSS_LENGTH_AUTO = cssLength('auto', true, false);
+const CSS_LENGTH_FOURTY_FOUR_PX = cssLength('44px', false, false);
+const CSS_LENGTH_SIXTY_PX = cssLength('60px', false, false);
 
 function getLayoutClass(layout) {
   if (!layout) {
@@ -115,11 +115,12 @@ function calculateLayout(inputLayout, width, height, sizesAttr, heightsAttr) {
   return 'fixed';
 }
 
-function cssLength(input, allowAuto) {
+function cssLength(input, allowAuto=false, allowFluid=false) {
   const result = {
     isValid: false,
     isSet: false,
     isAuto: false,
+    isFluid: false,
     numeral: Number.NaN,
     unit: 'px',
   };
@@ -134,6 +135,12 @@ function cssLength(input, allowAuto) {
   if (input === 'auto') {
     result.isAuto = true;
     result.isValid = allowAuto;
+    return result;
+  }
+
+  if (input === 'fluid') {
+    result.isFluid = true;
+    result.isValid = allowFluid;
     return result;
   }
 

--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -102,11 +102,18 @@ function maybeAddSizerInto(node, tree, layout, width, height) {
 module.exports = {
   applyLayout: function(customElement, tree) {
     const ampLayout = parseLayout(customElement.attribs.layout);
-    const inputWidth = cssLength(getAttributeOrNull(customElement, 'width'), false);
+    const inputWidth = cssLength(
+        getAttributeOrNull(customElement, 'width'),
+        /* allow_auto=*/true,
+        /* allow_fluid=*/false);
     if (!inputWidth.isValid) {
       return false;
     }
-    const inputHeight = cssLength(getAttributeOrNull(customElement, 'height'), false);
+    const inputHeight = cssLength(
+        getAttributeOrNull(customElement, 'height'),
+        /* allow_auto=*/true,
+        /* allow_fluid=*/ampLayout === 'fluid'
+    );
     if (!inputHeight.isValid) {
       return false;
     }

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-toolbox-optimizer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Server-side rendering for AMPs.",
   "main": "index.js",
   "repository": {

--- a/packages/optimizer/spec/lib/ParseLayoutSpec.js
+++ b/packages/optimizer/spec/lib/ParseLayoutSpec.js
@@ -84,6 +84,11 @@ describe('ParseLayout', () => {
         expect(parsed.isValid).toBe(true);
         expect(parsed.isAuto).toBe(true);
       }
+      {
+        const parsed = cssLength('fluid', false, true);
+        expect(parsed.isValid).toBe(true);
+        expect(parsed.isFluid).toBe(true);
+      }
     });
   });
   describe('getLayoutClass', () => {

--- a/packages/optimizer/spec/transformers/ServerSideRendering/transforms_layout_fixed-height/expected_output.html
+++ b/packages/optimizer/spec/transformers/ServerSideRendering/transforms_layout_fixed-height/expected_output.html
@@ -9,5 +9,12 @@
       style=height:100px;
       i-amphtml-layout=fixed-height>
     </amp-img>
+    <amp-img
+      width=auto
+      height=100 layout=fixed-height
+      class="i-amphtml-layout-fixed-height i-amphtml-layout-size-defined"
+      style=height:100px;
+      i-amphtml-layout=fixed-height>
+    </amp-img>
   </body>
 </html>

--- a/packages/optimizer/spec/transformers/ServerSideRendering/transforms_layout_fixed-height/input.html
+++ b/packages/optimizer/spec/transformers/ServerSideRendering/transforms_layout_fixed-height/input.html
@@ -2,5 +2,6 @@
   <head></head>
   <body>
     <amp-img height=100 layout=fixed-height></amp-img>
+    <amp-img width=auto height=100 layout=fixed-height></amp-img>
   </body>
 </html>


### PR DESCRIPTION
This resulted in the boilerplate not being removed for
layout=fixed-height width=auto height=100.

This commit also adds support for intrinsic and fluid layout, although
this are currently not supported by SSR.