### PR TITLE
cache-url: Replaced the Text Encoder with a More Browser Compatible Solution

### DIFF
--- a/packages/cache-url/lib/browser/Sha256.js
+++ b/packages/cache-url/lib/browser/Sha256.js
@@ -21,14 +21,28 @@
  */
 export default function browserSha256(str) {
   // Transform the string into an arraybuffer.
-  const buffer = new TextEncoder('utf-8').encode(str);
+  const buffer = stringToBuffer_(str);
   return crypto.subtle.digest('SHA-256', buffer).then((hash) => {
     return hex_(hash);
   });
 }
 
 /**
- * @param {string} buffer
+ * Function to convert a UTF-8 String to a buffer
+ * @param {string} str
+ * @return {Array<number>}
+ * @private
+ */
+function stringToBuffer_(str) {
+  const array = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    array[i] = str.charCodeAt(i);
+  }
+  return array.buffer;
+}
+
+/**
+ * @param {Array<number>} buffer
  * @return {string}
  * @private
  */


### PR DESCRIPTION
closes #135 

This replaces the Text Encode with a solution I made at: https://jsfiddle.net/torch2424/nhma9q3p

# Example

Added a simple log to make sure we were doing the sha256, not in PR. But shows we are getting the exact same hashes, and are producing the same buffers for our use case 😄 

![screen shot 2018-11-13 at 5 43 21 pm](https://user-images.githubusercontent.com/1448289/48454435-0a4b6e80-e76c-11e8-809d-c0c81c34c620.png)
