### PR TITLE
Make jimp a optional peerdependency

### DIFF
--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -83,7 +83,7 @@ You can find a sample implementation [here](demo/simple/). If you're using the e
 Currently the following options are supported:
 
 * **ampUrl**: an URL string pointing to the valid AMP version. Required by the AddAmpLink transformer.
-* **blurredPlaceholders**: enables blurry image placeholder generation. Default is `false`. **Important:** blurry image placeholder computation is expensive. Make sure to only use it for static or cached pages.
+* **blurredPlaceholders**: enables blurry image placeholder generation. Default is `false`. This transforms requires install `jimp`: `npm install jimp` **Important:** blurry image placeholder computation is expensive. Make sure to only use it for static or cached pages.
 * **imageBasePath**: a base URL or path required for resolving an image file from a given image `src` attribute. Used by for blurry image placeholder generation.
 * **maxBlurredPlaceholders**: specifies the max number of blurred images. Defaults to 5.
 * **ampRuntimeVersion** specifies a [specific version](https://github.com/ampproject/amp-toolbox/tree/master/runtime-version") of the AMP runtime. For example: `ampRuntimeVersion: "001515617716922"` will result in AMP runtime URLs being re-written from:

--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -83,7 +83,7 @@ You can find a sample implementation [here](demo/simple/). If you're using the e
 Currently the following options are supported:
 
 * **ampUrl**: an URL string pointing to the valid AMP version. Required by the AddAmpLink transformer.
-* **blurredPlaceholders**: enables blurry image placeholder generation. Default is `false`. This transforms requires install `jimp`: `npm install jimp` **Important:** blurry image placeholder computation is expensive. Make sure to only use it for static or cached pages.
+* **blurredPlaceholders**: enables blurry image placeholder generation. Default is `false`. This transforms requires install `jimp` and `lru-cache`: `npm install jimp lru-cache` **Important:** blurry image placeholder computation is expensive. Make sure to only use it for static or cached pages.
 * **imageBasePath**: a base URL or path required for resolving an image file from a given image `src` attribute. Used by for blurry image placeholder generation.
 * **maxBlurredPlaceholders**: specifies the max number of blurred images. Defaults to 5.
 * **ampRuntimeVersion** specifies a [specific version](https://github.com/ampproject/amp-toolbox/tree/master/runtime-version") of the AMP runtime. For example: `ampRuntimeVersion: "001515617716922"` will result in AMP runtime URLs being re-written from:

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -16,11 +16,15 @@
   ],
   "author": "AMPHTML Team",
   "license": "Apache-2.0",
+  "peerDependenciesMeta": {
+    "jimp": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "amp-toolbox-core": "^0.1.5",
     "amp-toolbox-runtime-version": "^0.2.6",
     "css": "^2.2.4",
-    "jimp": "0.6.0",
     "lru-cache": "^5.1.1",
     "parse5": "^5.1.0",
     "parse5-htmlparser2-tree-adapter": "^5.1.0"

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -19,13 +19,15 @@
   "peerDependenciesMeta": {
     "jimp": {
       "optional": true
+    },
+    "lru-cache": {
+      "optional": true
     }
   },
   "dependencies": {
     "amp-toolbox-core": "^0.1.5",
     "amp-toolbox-runtime-version": "^0.2.6",
     "css": "^2.2.4",
-    "lru-cache": "^5.1.1",
     "parse5": "^5.1.0",
     "parse5-htmlparser2-tree-adapter": "^5.1.0"
   },

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -31,6 +31,10 @@
     "parse5": "^5.1.0",
     "parse5-htmlparser2-tree-adapter": "^5.1.0"
   },
+  "devDependencies": {
+    "jimp": "0.6.0",	
+    "lru-cache": "^5.1.1"
+  },
   "bugs": {
     "url": "https://github.com/ampproject/amp-toolbox/issues"
   },


### PR DESCRIPTION
The way this is implemented is to avoid peerDependency warnings. We saw this issue with `unistore` where users would blindly install `preact`/`react` the moment they saw a peerdependency warning, even though the package doesn't need it to function correctly.

I've also updated the documentation.