### PR TITLE
Fix linting SXG requests

### DIFF
--- a/packages/linter/src/rules/SxgDumpSignedExchangeVerify.ts
+++ b/packages/linter/src/rules/SxgDumpSignedExchangeVerify.ts
@@ -33,7 +33,7 @@ export class SxgDumpSignedExchangeVerify extends Rule {
       sxg = await execa(CMD, ARGS, { input: body }).then(spawn => {
         const { stdout } = spawn;
         let m: ReturnType<typeof String.prototype.match>;
-        m = stdout.match(/^The exchange has valid signature.$/m);
+        m = stdout.match(/^The exchange has a valid signature.$/m);
         const isValid = !!m;
         m = stdout.match(/^format version: (\S+)$/m);
         const version = m && m[1];


### PR DESCRIPTION
The `dump-signedexchange` responds with `The exchange has a valid signature.`, instead of `The exchange has valid signature.`. This is why the linter returns an error.

I don't know how to test this repo (I ran into some errors). Therefore I am somewhat unsure if the verification now works correctly. So please retest this ;)

Edit: The dump-signedexchange fixed the message here: https://github.com/WICG/webpackage/commit/c7ef1c4bce81c7d1d3a60d5c17df4dcd0afb3cd3

Edit2:
On second thought, this could be easily done to be compatible with both versions of `dump-signedexchange`, if desired. Just let me know.