### PR TITLE
Use cross-fetch instead of node-fetch in core

### DIFF
--- a/packages/core/lib/oneBehindFetch.js
+++ b/packages/core/lib/oneBehindFetch.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-let fetch = require('node-fetch');
+let fetch = require('cross-fetch');
 const MaxAge = require('./MaxAge.js');
 
 const cache = new Map();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/ampproject/amp-toolbox/tree/master/packages/core",
   "dependencies": {
-    "node-fetch": "2.6.0"
+    "cross-fetch": "3.0.4"
   },
   "gitHead": "cb496f081c871a25dc73113ae1e1fccfb59b2732"
 }

--- a/packages/core/spec/lib/OneBehindFetchSpec.js
+++ b/packages/core/spec/lib/OneBehindFetchSpec.js
@@ -17,7 +17,7 @@
 
 const oneBehindFetch = require('../../lib/oneBehindFetch.js');
 const mockFetch = require('fetch-mock');
-const nodeFetch = require('node-fetch');
+const nodeFetch = require('cross-fetch');
 const fetch = mockFetch.sandbox();
 
 


### PR DESCRIPTION
This makes core isomorphic in theory (valid for both browser and node.js), which makes it easier to use from other isomorphic packages in this repo.

Related to #378.