### PR TITLE
Replace oneBehindFetch with cross-fetch in validator-rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     "@ampproject/toolbox-cache-list": {
       "version": "file:packages/cache-list",
       "requires": {
-        "@ampproject/toolbox-core": "^1.0.0-beta.3"
+        "@ampproject/toolbox-core": "^1.0.0-beta.4"
       },
       "dependencies": {
         "@ampproject/toolbox-core": {
@@ -43,12 +43,12 @@
     "@ampproject/toolbox-cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^1.0.0-beta.3",
-        "@ampproject/toolbox-cache-url": "^1.0.0-beta.3",
-        "@ampproject/toolbox-linter": "^1.0.0-beta.3",
-        "@ampproject/toolbox-optimizer": "^1.0.0-beta.3",
-        "@ampproject/toolbox-runtime-version": "^1.0.0-beta.3",
-        "@ampproject/toolbox-update-cache": "^1.0.0-beta.3",
+        "@ampproject/toolbox-cache-list": "^1.0.0-beta.4",
+        "@ampproject/toolbox-cache-url": "^1.0.0-beta.4",
+        "@ampproject/toolbox-linter": "^1.0.0-beta.4",
+        "@ampproject/toolbox-optimizer": "^1.0.0-beta.4",
+        "@ampproject/toolbox-runtime-version": "^1.0.0-beta.4",
+        "@ampproject/toolbox-update-cache": "^1.0.0-beta.4",
         "minimist": "1.2.0",
         "node-fetch": "2.6.0"
       },
@@ -141,9 +141,9 @@
     "@ampproject/toolbox-cors": {
       "version": "file:packages/cors",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^1.0.0-beta.3",
-        "@ampproject/toolbox-cache-url": "^1.0.0-beta.3",
-        "@ampproject/toolbox-core": "^1.0.0-beta.3"
+        "@ampproject/toolbox-cache-list": "^1.0.0-beta.4",
+        "@ampproject/toolbox-cache-url": "^1.0.0-beta.4",
+        "@ampproject/toolbox-core": "^1.0.0-beta.4"
       },
       "dependencies": {
         "@ampproject/toolbox-cache-list": {
@@ -176,8 +176,8 @@
     "@ampproject/toolbox-linter": {
       "version": "file:packages/linter",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^1.0.0-beta.3",
-        "@ampproject/toolbox-cache-url": "^1.0.0-beta.3",
+        "@ampproject/toolbox-cache-list": "^1.0.0-beta.4",
+        "@ampproject/toolbox-cache-url": "^1.0.0-beta.4",
         "amphtml-validator": "1.0.23",
         "cheerio": "1.0.0-rc.2",
         "commander": "2.20.0",
@@ -4330,8 +4330,8 @@
     "@ampproject/toolbox-optimizer": {
       "version": "file:packages/optimizer",
       "requires": {
-        "@ampproject/toolbox-core": "^1.0.0-beta.3",
-        "@ampproject/toolbox-runtime-version": "^1.0.0-beta.3",
+        "@ampproject/toolbox-core": "^1.0.0-beta.4",
+        "@ampproject/toolbox-runtime-version": "^1.0.0-beta.4",
         "css": "2.2.4",
         "parse5": "5.1.0",
         "parse5-htmlparser2-tree-adapter": "5.1.0"
@@ -4363,9 +4363,9 @@
     "@ampproject/toolbox-optimizer-express": {
       "version": "file:packages/optimizer-express",
       "requires": {
-        "@ampproject/toolbox-core": "^1.0.0-beta.3",
-        "@ampproject/toolbox-optimizer": "^1.0.0-beta.3",
-        "@ampproject/toolbox-runtime-version": "^1.0.0-beta.3",
+        "@ampproject/toolbox-core": "^1.0.0-beta.4",
+        "@ampproject/toolbox-optimizer": "^1.0.0-beta.4",
+        "@ampproject/toolbox-runtime-version": "^1.0.0-beta.4",
         "mime-types": "2.1.24",
         "whatwg-url": "7.0.0"
       },
@@ -4421,7 +4421,7 @@
     "@ampproject/toolbox-runtime-version": {
       "version": "file:packages/runtime-version",
       "requires": {
-        "@ampproject/toolbox-core": "^1.0.0-beta.3"
+        "@ampproject/toolbox-core": "^1.0.0-beta.4"
       },
       "dependencies": {
         "@ampproject/toolbox-core": {
@@ -4437,8 +4437,8 @@
     "@ampproject/toolbox-update-cache": {
       "version": "file:packages/update-cache",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^1.0.0-beta.3",
-        "@ampproject/toolbox-cache-url": "^1.0.0-beta.3",
+        "@ampproject/toolbox-cache-list": "^1.0.0-beta.4",
+        "@ampproject/toolbox-cache-url": "^1.0.0-beta.4",
         "jsrsasign": "8.0.12"
       },
       "dependencies": {
@@ -4472,7 +4472,7 @@
     "@ampproject/toolbox-validator-rules": {
       "version": "file:packages/validator-rules",
       "requires": {
-        "@ampproject/toolbox-core": "^1.0.0-beta.3"
+        "cross-fetch": "3.0.4"
       },
       "dependencies": {
         "@ampproject/toolbox-core": {
@@ -9426,6 +9426,15 @@
       "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
       }
     },
     "cross-spawn": {
@@ -18692,6 +18701,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-url": {
       "version": "7.0.0",

--- a/packages/validator-rules/lib/loadRules.js
+++ b/packages/validator-rules/lib/loadRules.js
@@ -17,12 +17,12 @@
 // This solution is temporary and will be replaced when
 // https://github.com/ampproject/amp-toolbox/issues/378 is resolved.
 
-const {oneBehindFetch} = require('@ampproject/toolbox-core');
+const fetch = require('cross-fetch');
 
 const VALIDATOR_RULES_URL = 'https://cdn.ampproject.org/v0/validator.json';
 
 async function loadRemote(url) {
-  const req = await oneBehindFetch(url);
+  const req = await fetch(url);
   return req.json();
 }
 

--- a/packages/validator-rules/package.json
+++ b/packages/validator-rules/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/ampproject/amp-toolbox/issues"
   },
   "dependencies": {
-    "@ampproject/toolbox-core": "^1.0.0-beta.4"
+    "cross-fetch": "3.0.4"
   },
   "homepage": "https://github.com/ampproject/amp-toolbox/tree/master/packages/validator-rules",
   "directories": {


### PR DESCRIPTION
It seems the current solution with `oneBehindFetch` has some odd behavior here. Since this is temporary anyway (#378), just replacing it with `cross-fetch` should work.