### PR TITLE
Fix "amp lint [url]"

### DIFF
--- a/packages/cli/spec/cmds/lintSpec.js
+++ b/packages/cli/spec/cmds/lintSpec.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const curlsCmd = require('../../lib/cmds/lint.js');
+const MockLogger = require('../helpers/MockLogger');
+
+describe('curls', () => {
+  const mockLogger = new MockLogger();
+
+  afterEach(() => {
+    mockLogger.clear();
+  });
+
+  it('runs at least one successful test', (done) => {
+    curlsCmd({_: ['', 'https://amp.dev']}, mockLogger)
+        .then(() => {
+          const output = mockLogger.logs;
+          expect(output).toMatch(/PASS/m);
+          done();
+        })
+        .catch((e) => done.fail(e));
+  });
+});

--- a/packages/cli/spec/cmds/lintSpec.js
+++ b/packages/cli/spec/cmds/lintSpec.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-const curlsCmd = require('../../lib/cmds/lint.js');
+const lintCmd = require('../../lib/cmds/lint.js');
 const MockLogger = require('../helpers/MockLogger');
 
 describe('lint', () => {
@@ -27,7 +27,7 @@ describe('lint', () => {
   });
 
   it('runs at least one successful test', (done) => {
-    curlsCmd({_: ['', 'https://amp.dev']}, mockLogger)
+    lintCmd({_: ['', 'https://amp.dev']}, mockLogger)
         .then(() => {
           const output = mockLogger.logs;
           expect(output).toMatch(/PASS/m);

--- a/packages/cli/spec/cmds/lintSpec.js
+++ b/packages/cli/spec/cmds/lintSpec.js
@@ -19,7 +19,7 @@
 const curlsCmd = require('../../lib/cmds/lint.js');
 const MockLogger = require('../helpers/MockLogger');
 
-describe('curls', () => {
+describe('lint', () => {
   const mockLogger = new MockLogger();
 
   afterEach(() => {

--- a/packages/linter/src/cli.ts
+++ b/packages/linter/src/cli.ts
@@ -111,7 +111,7 @@ export function cli(argv: string[], logger = console) {
     url: string;
     headers: { [k: string]: string };
   })
-    .then(logger.log)
+    .then(logger.info.bind(logger))
     .catch(e => {
       logger.error(e.stack || e.message || e);
       process.exitCode = 1;


### PR DESCRIPTION
I think this fixes the broken code in packages/linter that was causing "amp lint" to generate no output, and also adds a test to prevent this happening again.

(CI likely to fail because the contents of `packages/cli/node_modules/@ampproject/*` seem to be installed directly from the npm repo (i.e. they aren't copies or symlinks to the local packages) and so even though the `toolbox-linter` module is actually updated, the tests are run against the old (published) version.)