### PR TITLE
Add log.success() fn

### DIFF
--- a/packages/core/lib/Log.js
+++ b/packages/core/lib/Log.js
@@ -39,6 +39,10 @@ class Log {
     this.log_(this.output_.log, message, ...args);
   }
 
+  success(message, ...args) {
+    this.log_(this.output_.log, this.green_('SUCCESS ' + message), args);
+  }
+
   warn(message, ...args) {
     this.log_(this.output_.warn, this.yellow_('WARNING ' + message), args);
   }
@@ -77,6 +81,10 @@ class Log {
 
   dim_(string) {
     return `\x1b[36m${string}\x1b[0m`;
+  }
+
+  green_(string) {
+    return `\x1b[32m${string}\x1b[0m`;
   }
 
   yellow_(string) {


### PR DESCRIPTION
Fixes #453.

Definitely can see a use-case for `log.success()`, so this adds the missing function into `core/lib/Log.js` - styled green.

So `amp update-cache` doesn't throw any more.

![image](https://user-images.githubusercontent.com/9677698/63222585-87fd4880-c1dc-11e9-913d-0684b8f57555.png)
