### PR TITLE
Improve SXG Vary test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5840,7 +5840,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -8256,7 +8256,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -9457,7 +9457,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -9673,7 +9673,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -9754,7 +9754,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -9763,7 +9763,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }

--- a/packages/linter/README.md
+++ b/packages/linter/README.md
@@ -22,7 +22,7 @@ $ node src/cli.js https://amp.dev/
 
 Command-line (from npm):
 
-```sh
+```sh <!-- markdownlint-disable MD014 -->
 $ npx @ampproject/toolbox-linter https://amp.dev/
 ```
 
@@ -54,7 +54,7 @@ performed.
 ## Development
 
 **Important note!** Many of the scripts below rely on binaries that are
-installed in the `../../node_modules/.bin` directory, and *will fail* if invoked
+installed in the `../../node_modules/.bin` directory, and _will fail_ if invoked
 in the default configuration. To fix this, either:
 
 1. Add `../../node_modules/.bin` to your path. A tool like

--- a/packages/linter/src/rules/SxgVaryOnAcceptAct.ts
+++ b/packages/linter/src/rules/SxgVaryOnAcceptAct.ts
@@ -5,10 +5,7 @@ import { Rule } from "../rule";
 
 export class SxgVaryOnAcceptAct extends Rule {
   async run({ url, headers }: Context) {
-    headers = {
-      ...headers,
-      accept: "text/html,application/signed-exchange;v=b3"
-    };
+    headers.accept = "text/html,application/signed-exchange;v=b3";
     const res = await fetch(url, { headers });
     const debug = `debug: ${fetchToCurl(url, { headers })}`;
     const vary = ("" + res.headers.get("vary"))

--- a/packages/linter/src/rules/SxgVaryOnAcceptAct.ts
+++ b/packages/linter/src/rules/SxgVaryOnAcceptAct.ts
@@ -5,6 +5,10 @@ import { Rule } from "../rule";
 
 export class SxgVaryOnAcceptAct extends Rule {
   async run({ url, headers }: Context) {
+    headers = {
+      ...headers,
+      accept: "text/html,application/signed-exchange;v=b3"
+    };
     const res = await fetch(url, { headers });
     const debug = `debug: ${fetchToCurl(url, { headers })}`;
     const vary = ("" + res.headers.get("vary"))


### PR DESCRIPTION
Change the setup for the SxgVaryOnAcceptAct test as discussed in #456 so that the request includes the `accept` header `"text/html,application/signed-exchange;v=b3"`. (Servers can respond with whatever `vary` header they like if this header is not included.)

Fixes #456.