### PR TITLE
check 'amp-same-origin' header before 'origin' header

### DIFF
--- a/packages/cors/lib/cors.js
+++ b/packages/cors/lib/cors.js
@@ -107,24 +107,19 @@ module.exports = (options, caches=new Caches()) => {
    * @private
    */
   function extractOriginHeaders_(headers) {
-    const result = {
-      isSameOrigin: false,
-    };
-    for (const key in headers) {
-      if (headers.hasOwnProperty(key)) {
-        const normalizedKey = key.toLowerCase();
-        // for same-origin requests where the Origin header is missing, AMP sets the amp-same-origin header
-        if (normalizedKey === 'amp-same-origin') {
-          result.isSameOrigin = true;
-          return result;
-        }
-        // use the origin header otherwise
-        if (normalizedKey === 'origin') {
-          result.origin = headers[key];
-          return result;
-        }
-      }
+    // for same-origin requests AMP sets the amp-same-origin header
+    if ('amp-same-origin' in headers) {
+      return {
+        isSameOrigin: true,
+      };
+    } else if ('origin' in headers) {
+      // use the origin header otherwise
+      return {
+        isSameOrigin: false,
+        origin: headers.origin,
+      };
     }
+
     return null;
   }
 

--- a/packages/cors/lib/cors.js
+++ b/packages/cors/lib/cors.js
@@ -107,16 +107,24 @@ module.exports = (options, caches=new Caches()) => {
    * @private
    */
   function extractOriginHeaders_(headers) {
+    const normalizedHeaders = {};
+
+    for (const key in headers) {
+      if (headers.hasOwnProperty(key)) {
+        normalizedHeaders[key.toLowerCase()] = headers[key];
+      }
+    }
+
     // for same-origin requests AMP sets the amp-same-origin header
-    if ('amp-same-origin' in headers) {
+    if ('amp-same-origin' in normalizedHeaders) {
       return {
         isSameOrigin: true,
       };
-    } else if ('origin' in headers) {
+    } else if ('origin' in normalizedHeaders) {
       // use the origin header otherwise
       return {
         isSameOrigin: false,
-        origin: headers.origin,
+        origin: normalizedHeaders.origin,
       };
     }
 


### PR DESCRIPTION
https://github.com/ampproject/amp-toolbox/issues/487

doesn't pick up `origin` on same origin requests where `amp-same-origin` is set