### PR TITLE
fix(amp-optimizer): no need validAMP in DomTransformer

### DIFF
--- a/packages/optimizer/spec/valid-amp/ValidAmpSpec.js
+++ b/packages/optimizer/spec/valid-amp/ValidAmpSpec.js
@@ -21,7 +21,7 @@ const {writeFileSync} = require('fs');
 
 const {DomTransformer} = require('../../lib/DomTransformer.js');
 
-const ampOptimizer = new DomTransformer({validAmp: true});
+const ampOptimizer = new DomTransformer();
 
 const files = getResources(join(__dirname, 'files')).filter((f) => f.endsWith('.html'));
 


### PR DESCRIPTION
`validAMP` option is not needed for `DomTransformer` anymore by this following fixes.

https://github.com/ampproject/amp-toolbox/pull/306/

Is it correct?
