### PR TITLE
optimizer: Make dynamic component URL rewrites optional

### DIFF
--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -193,6 +193,8 @@ It's possible to rewrite the AMP framework and component imports to a different 
 
   **Notice:** The behavior of `ampUrlPrefix` when used in conjunction with `ampRuntimeVersion` changed beginning with version 1.1.2. Prior to 1.1.2, `rtv/{rtv}/` was automatically appended to `ampUrlPrefix` when `ampRuntimeVersion` was specified. Since version 1.1.2, `ampUrlPrefix` is not modified when `ampRuntimeVersion` is also specified.
 
+- `rewriteDynamicComponents`: When used in conjunction with `ampUrlPrefix`, this option can be set to `false` to prevent [dynamic AMP components](https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-guidelines.md#guidelines-adding-a-new-cache-to-the-amp-ecosystem) from having their URLs rewritten.
+
 Examples:
 ```
 const ampOptimizer = require('@ampproject/toolbox-optimizer');
@@ -204,14 +206,27 @@ const originalHtml = `
 ...
 `
 
-// this will rewrite https://cdn.ampproject.org/v0.js to /amp/v0.js
+// this will rewrite https://cdn.ampproject.org/v0.js to /amp/v0.js and will
+// rewrite dynamic component https://cdn.ampproject.org/v0/amp-geo-0.1.js to
+// /amp/v0/amp-geo-0.1.js
 const optimizedHtmlA = await ampOptimizer.transformHtml(originalHtml, {
   ampUrlPrefix: '/amp'
 });
 
-// this will rewrite https://cdn.ampproject.org/v0.js to /amp/v0.js
+// this will rewrite https://cdn.ampproject.org/v0.js to /amp/v0.js and will
+// not rewrite dynamic component https://cdn.ampproject.org/v0/amp-geo-0.1.js
 const optimizedHtmlB = await ampOptimizer.transformHtml(originalHtml, {
+  ampUrlPrefix: '/amp',
+  rewriteDynamicComponents: false
+});
+
+// this will rewrite https://cdn.ampproject.org/v0.js to
+// /amp/001515617716922/v0.js and will rewrite dynamic component
+// https://cdn.ampproject.org/v0/amp-geo-0.1.js to
+// https://cdn.ampproject.org/v0/rtv/001515617716922/amp-geo-0.1.js
+const optimizedHtmlC = await ampOptimizer.transformHtml(originalHtml, {
   ampRuntimeVersion: '001515617716922',
-  ampUrlPrefix: '/amp'
+  ampUrlPrefix: '/amp/001515617716922',
+  rewriteDynamicComponents: false
 });
 ```

--- a/packages/optimizer/lib/AmpConstants.js
+++ b/packages/optimizer/lib/AmpConstants.js
@@ -18,5 +18,11 @@
 module.exports = {
   AMP_TAGS: ['amp', '⚡', '⚡4ads'],
   AMP_CACHE_HOST: 'https://cdn.ampproject.org',
+  // Should be kept up to date with dynamic components listed here:
+  // https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-guidelines.md#guidelines-adding-a-new-cache-to-the-amp-ecosystem
+  AMP_DYNAMIC_COMPONENTS: {
+    'custom-element': ['amp-geo'],
+    'custom-template': [],
+  },
   appendRuntimeVersion: (prefix, version) => prefix + '/rtv/' + version,
 };

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_with_rtv/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_with_rtv/expected_output.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <link rel="preload" href="/amp/v0.js" as="script">
+  <link rel="preload" href="/amp/v0.css" as="style">
+  <script async custom-element=amp-experiment src=/amp/v0/amp-experiment-0.1.js></script>
+  <script async custom-element=amp-geo src=https://cdn.ampproject.org/rtv/001515617716922/v0/amp-geo-0.1.js></script>
+  <script async src="/amp/v0.js"></script>
+  <link rel=stylesheet href=/amp/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_with_rtv/input.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_with_rtv/input.html
@@ -1,0 +1,19 @@
+<!--
+{
+  "ampUrlPrefix": "/amp",
+  "ampRuntimeVersion": "001515617716922",
+  "rewriteDynamicComponents": false
+}
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element=amp-experiment src=https://cdn.ampproject.org/v0/amp-experiment-0.1.js></script>
+  <script async custom-element=amp-geo src=https://cdn.ampproject.org/v0/amp-geo-0.1.js></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel=stylesheet href=https://cdn.ampproject.org/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_without_rtv/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_without_rtv/expected_output.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <link rel="preload" href="/amp/v0.js" as="script">
+  <link rel="preload" href="/amp/v0.css" as="style">
+  <script async custom-element=amp-experiment src=/amp/v0/amp-experiment-0.1.js></script>
+  <script async custom-element=amp-geo src=https://cdn.ampproject.org/v0/amp-geo-0.1.js></script>
+  <script async src="/amp/v0.js"></script>
+  <link rel=stylesheet href=/amp/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_without_rtv/input.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_but_not_dynamic_components_without_rtv/input.html
@@ -1,0 +1,18 @@
+<!--
+{
+  "ampUrlPrefix": "/amp",
+  "rewriteDynamicComponents": false
+}
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element=amp-experiment src=https://cdn.ampproject.org/v0/amp-experiment-0.1.js></script>
+  <script async custom-element=amp-geo src=https://cdn.ampproject.org/v0/amp-geo-0.1.js></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel=stylesheet href=https://cdn.ampproject.org/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
DEPENDS ON #517

Not everyone who self-hosts the AMP runtime has the infrastructure to
support dynamic components like `amp-geo`, ref: [AMP cache guidelines](https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-guidelines.md#guidelines-adding-a-new-cache-to-the-amp-ecosystem).

Introduce option rewriteDynamicComponents that prevents modification of
dynamic component URLs that would otherwise have ampUrlPrefix
substituted.

Two relevant tests added:
- rewrites_host_but_not_dynamic_components_with_rtv
- rewrites_host_but_not_dynamic_components_without_rtv

Fixes #515