### PR TITLE
fixes include examples to use toolbox-cache-url

### DIFF
--- a/packages/cache-url/README.md
+++ b/packages/cache-url/README.md
@@ -18,13 +18,13 @@ $ npm install @ampproject/toolbox-cache-url
 #### ES Module (Browser)
 
 ```javascript
-import {ampToolboxCacheUrl} from 'amp-toolbox-cache-url';
+import {ampToolboxCacheUrl} from 'toolbox-cache-url';
 ```
 
 #### CommonJs (Node)
 
 ```javascript
-const ampToolboxCacheUrl = require('amp-toolbox-cache-url').createCacheUrl;
+const ampToolboxCacheUrl = require('@ampproject/toolbox-cache-url');
 ```
 
 
@@ -33,7 +33,7 @@ const ampToolboxCacheUrl = require('amp-toolbox-cache-url').createCacheUrl;
 In the browser, include the UMD module in an HTML `<script>` tag. If using node, replace `window` with `global`.
 
 ```javascript
-const {ampToolboxCacheUrl} = window.AmpToolboxCacheUrl;
+const {ampToolboxCacheUrl} = window.ToolboxCacheUrl;
 ```
 
 ### Using the module


### PR DESCRIPTION
Documentation had errata from older name of module not being updated in every example