### PR TITLE
optimizer: Add meta tags for singleDoc self-host

### DIFF
--- a/packages/optimizer/lib/transformers/RewriteAmpUrls.js
+++ b/packages/optimizer/lib/transformers/RewriteAmpUrls.js
@@ -67,6 +67,11 @@ class RewriteAmpUrls {
       }
       node = node.nextSibling;
     }
+
+    if (!this._usesAmpCacheUrl(host)) {
+      const versionlessHost = calculateHost({ampUrlPrefix: params.ampUrlPrefix});
+      referenceNode = this._addMeta(head, referenceNode, 'runtime-host', versionlessHost);
+    }
   }
 
   _usesAmpCacheUrl(url) {
@@ -92,6 +97,12 @@ class RewriteAmpUrls {
     });
     insertAfter(parent, preload, node);
     return preload;
+  }
+
+  _addMeta(parent, node, name, content) {
+    const meta = createElement('meta', {name, content});
+    insertAfter(parent, meta, node);
+    return meta;
   }
 }
 

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* v0.css */</style>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <link rel="preload" href="/amp/rtv/123456789000000/v0.js" as="script">
+  <meta name="runtime-host" content="/amp">
   <script async src="/amp/rtv/123456789000000/v0.js"></script>
   <script async custom-element="amp-experiment" src="/amp/rtv/123456789000000/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-video" src="/amp/rtv/123456789000000/v0/amp-video-0.1.js"></script>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
@@ -8,6 +8,7 @@
   <link href="https://example.com/favicon.ico" rel="icon">
   <link rel="preload" href="/amp/rtv/001515617716922/v0.js" as="script">
   <link rel="preload" href="/amp/rtv/001515617716922/v0.css" as="style">
+  <meta name="runtime-host" content="/amp">
 </head>
 <body></body>
 </html>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
@@ -8,6 +8,7 @@
   <link href="https://example.com/favicon.ico" rel="icon">
   <link rel="preload" href="/amp/v0.js" as="script">
   <link rel="preload" href="/amp/v0.css" as="style">
+  <meta name="runtime-host" content="/amp">
 </head>
 <body></body>
 </html>


### PR DESCRIPTION
Add meta tags to AMP documents to support self-hosted AMP runtime
support when AMP pages are viewed in single-doc mode.