### PR TITLE
Use relative links compatible with github&npmjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ limitations under the License.
 
 A collection of AMP tools making it easier to publish and host AMP pages. The following tools are part of this project:
 
-- **[amp-cache-url](./packages/cache-url):** a javascript library for translating origin URLs to the [AMP Cache URL format](https://developers.google.com/amp/cache/overview).
-- **[amp-cache-list](./packages/cache-list):** a javascript library for listing the known AMP Caches.
-- **[amp-cli](./packages/cli):** a command line version of AMP Toolbox
-- **[amp-cors](./packages/cors):** a connect/express middleware to automatically add [AMP Cors headers](https://www.ampproject.org/docs/fundamentals/amp-cors-requests).
-- **[amp-linter](./packages/linter):** a javascript library for linting AMP documents (includes CLI mode).
-- **[amp-optimizer](./packages/optimizer):** a javascript library implementing server-side-rendering for AMP pages.
-- **[amp-optimizer-express](./packages/optimizer-express)** an [express](http://expressjs.com/) middleware that applies AMP server-side-rendering on the fly.
-- **[amp-runtime-fetch](./packages/runtime-fetch):** a javascript library for downloading the AMP runtime.
-- **[amp-runtime-version](./packages/runtime-version):** a javascript library for querying the current AMP runtime version.
-- **[amp-script-csp](./packages/script-csp):** a javascript library for calculating [`amp-script`](https://amp.dev/documentation/components/amp-script/) compatible CSP hashes.
-- **[amp-update-cache](./packages/update-cache):** a javascript library for updating AMP documents in AMP Caches.
-- **[amp-validator-rules](./packages/validator-rules):** a javascript library for querying AMP validator rules.
+- **[amp-cache-url](/packages/cache-url):** a javascript library for translating origin URLs to the [AMP Cache URL format](https://developers.google.com/amp/cache/overview).
+- **[amp-cache-list](/packages/cache-list):** a javascript library for listing the known AMP Caches.
+- **[amp-cli](/packages/cli):** a command line version of AMP Toolbox
+- **[amp-cors](/packages/cors):** a connect/express middleware to automatically add [AMP Cors headers](https://www.ampproject.org/docs/fundamentals/amp-cors-requests).
+- **[amp-linter](/packages/linter):** a javascript library for linting AMP documents (includes CLI mode).
+- **[amp-optimizer](/packages/optimizer):** a javascript library implementing server-side-rendering for AMP pages.
+- **[amp-optimizer-express](/packages/optimizer-express)** an [express](http://expressjs.com/) middleware that applies AMP server-side-rendering on the fly.
+- **[amp-runtime-fetch](/packages/runtime-fetch):** a javascript library for downloading the AMP runtime.
+- **[amp-runtime-version](/packages/runtime-version):** a javascript library for querying the current AMP runtime version.
+- **[amp-script-csp](/packages/script-csp):** a javascript library for calculating [`amp-script`](https://amp.dev/documentation/components/amp-script/) compatible CSP hashes.
+- **[amp-update-cache](/packages/update-cache):** a javascript library for updating AMP documents in AMP Caches.
+- **[amp-validator-rules](/packages/validator-rules):** a javascript library for querying AMP validator rules.
 
 ## Development
 
@@ -55,7 +55,7 @@ npm test
 
 ### Adding new dependencies
 
-amp-toolbox uses [Lerna](https://lerna.js.org/) to manage it's packages. To keep build times low, `devDependencies` ([but not CLI dependencies](https://github.com/lerna/lerna/issues/1079#issuecomment-337660289)) must be added to the root [package.json](package.json) file. Runtime dependencies are managed for each package individually.
+amp-toolbox uses [Lerna](https://lerna.js.org/) to manage it's packages. To keep build times low, `devDependencies` ([but not CLI dependencies](https://github.com/lerna/lerna/issues/1079#issuecomment-337660289)) must be added to the root [package.json](/package.json) file. Runtime dependencies are managed for each package individually.
 
 When adding a new package inside the `packages` directory, register the package via:
 
@@ -92,8 +92,8 @@ npm run lint:fix
 
 ## Contributing
 
-Please see [the CONTRIBUTING file](CONTRIBUTING.md) for information on contributing to the AMP Project.
+Please see [the CONTRIBUTING file](/CONTRIBUTING.md) for information on contributing to the AMP Project.
 
 ## License
 
-AMP Toolbox is made by the [AMP Project](https://www.ampproject.org/), and is licensed under the [Apache License, Version 2.0](./LICENSE).
+AMP Toolbox is made by the [AMP Project](https://www.ampproject.org/), and is licensed under the [Apache License, Version 2.0](/LICENSE).

--- a/packages/cors/README.md
+++ b/packages/cors/README.md
@@ -107,7 +107,7 @@ app.use(ampCors({
 
 ## Example
 
-See [express.js](demo/express.js) for a sample implementation. There are two scenarios in which the AMP CORS header will be added:
+See [express.js](/packages/cors/demo/express.js) for a sample implementation. There are two scenarios in which the AMP CORS header will be added:
 
 1. AMP CORS header will be set if the `__amp_source_origin` query parameter is set together with the `AMP-SAME-ORIGIN` header:
 

--- a/packages/optimizer-express/README.md
+++ b/packages/optimizer-express/README.md
@@ -6,12 +6,12 @@ amp-optimizer-express is an [express](http://expressjs.com/) middleware that opt
 times for websites using AMP for their canonical pages. The middleware uses the same
 server-side-rendering optimizations as the Google AMP Cache.
 
-The middleware uses the [amp-optimizer](../optimizer) component to apply server-side-rendering on the fly.
+The middleware uses the [amp-optimizer](/packages/optimizer) component to apply server-side-rendering on the fly.
 
 ## How it works
 
 amp-optimizer-express intercepts the responses and replaces their content with a version that has been
-transformed by [amp-optimizer](../optimizer).
+transformed by [amp-optimizer](/packages/optimizer).
 
 As the server-side-rendered version of the content is not valid AMP, the component also
 provides the original content on an alternative URL. Server-side-rendering

--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -1,7 +1,6 @@
 # AMP Optimizer
 
 [![npm version](https://badge.fury.io/js/%40ampproject%2Ftoolbox-optimizer.svg)](https://badge.fury.io/js/%40ampproject%2Ftoolbox-optimizer)
-[![changelog](https://img.shields.io/badge/Changelog-2.0-%235500d7)](CHANGELOG.md)
 
 AMP Optimizer is a tool to simplify creating AMP pages and improve AMP rendering performance. AMP Optimizer implements [AMP performance best practices](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp?format=websites) and supports [AMP server-side-rendering](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/server-side-rendering?format=websites). By default, it will perform the following optimizations:
 
@@ -47,7 +46,7 @@ ampOptimizer.transformHtml(originalHtml).then((optimizedHtml) => {
 });
 ```
 
-You can find a sample implementation [here](demo/simple/). If you're using express to serve your site, you can use the [AMP Optimizer Middleware](../optimizer-express).
+You can find a sample implementation [here](/packages/optimizer/demo/simple). If you're using express to serve your site, you can use the [AMP Optimizer Middleware](/packages/optimizer-express).
 
 ### Incomplete markup
 
@@ -134,7 +133,7 @@ const amphtml = await ampOptimizer.transformHtml(html, {
 });
 ```
 
-You can find a working sample [here](demo/markdown/).
+You can find a working sample [here](/packages/optimizer/demo/markdown).
 
 ### Custom transformations
 
@@ -175,11 +174,11 @@ const transformedHtml = await optimizer.transformHtml(html, {
 });
 ```
 
-Checkout [the samples](demo/simple/index.js) to learn how to customize AMP Optimizer.
+Checkout [the samples](/packages/optimizer/demo/simple/index.js) to learn how to customize AMP Optimizer.
 
 ### CLI
 
-There's also a [command line version](../cli/README.md) available:
+There's also a [command line version](/packages/cli/README.md) available:
 
 ```shell
 $ npx @ampproject/toolbox-cli myFile.html
@@ -264,7 +263,7 @@ Versioning the AMP runtime URLs has one main benefit: versioned AMP runtime URLs
 
 **Important:** when using versioned AMP runtime URLs make sure to invalidate all caches whenever a new AMP runtime is released. This is to ensure that your AMP pages always use the latest version of the AMP runtime.
 
-You can use [@ampproject/toolbox-runtime-version](../@ampproject/toolbox-runtime-version) to retrieve the latest version of the AMP runtime. Here is a sample to apply the optimizations including versioning the URLs:
+You can use [@ampproject/toolbox-runtime-version](/packages/runtime-version) to retrieve the latest version of the AMP runtime. Here is a sample to apply the optimizations including versioning the URLs:
 
 ```
 const ampOptimizer = require('@ampproject/toolbox-optimizer');

--- a/packages/update-cache/README.md
+++ b/packages/update-cache/README.md
@@ -2,8 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/%40ampproject%2Ftoolbox-update-cache.svg)](https://badge.fury.io/js/%40ampproject%2Ftoolbox-update-cache)
 
-Generates AMP Cache invalidation URLs for all known AMP Caches. For more info see the [Google AMP Cache documentation](
-https://developers.google.com/amp/cache/update-ping#update-cache-request).
+Generates AMP Cache invalidation URLs for all known AMP Caches. For more info see the [Google AMP Cache documentation](https://developers.google.com/amp/cache/update-ping#update-cache-request).
 
 ## Usage
 


### PR DESCRIPTION
Uniformly use relative links in readme markdown documents that are
relative to the root of the amp-toolbox repo. These should work
correctly on npmjs.

Remove changelog badge from optimizer readme.

Fixes #661