### PR TITLE
runtime-version: Update for custom hosts and lts

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -54,6 +54,10 @@ class Cli {
               type: 'boolean',
               default: false,
             },
+            lts: {
+              type: 'boolean',
+              default: false,
+            },
           })
         );
         break;

--- a/packages/cli/lib/cmds/helpMessages.js
+++ b/packages/cli/lib/cmds/helpMessages.js
@@ -34,6 +34,7 @@ module.exports = {
     '',
     'Options:',
     '--canary .................. Get canary version. Defaults to false.',
+    '--lts ..................... Get long-term stable version. Defaults to false.',
     '--host .................... AMP host. Defaults to https://cdn.ampproject.org.',
   ].join('\n'),
   'curls': [

--- a/packages/cli/lib/cmds/runtimeVersion.js
+++ b/packages/cli/lib/cmds/runtimeVersion.js
@@ -19,12 +19,13 @@
 const ampRuntimeVersionProvider = require('@ampproject/toolbox-runtime-version');
 
 async function runtimeVersion(args, logger) {
-  const {canary, host} = args;
+  const {canary, host, lts} = args;
   const version = await ampRuntimeVersionProvider.currentVersion({
     ampUrlPrefix: host,
     canary,
+    lts,
   });
-  logger.info(version);
+  logger.info(version || '');
 }
 
 module.exports = runtimeVersion;

--- a/packages/runtime-version/lib/RuntimeVersion.js
+++ b/packages/runtime-version/lib/RuntimeVersion.js
@@ -19,33 +19,52 @@ const log = require('@ampproject/toolbox-core').log.tag('AMP Runtime Version');
 
 const AMP_CACHE_HOST = 'https://cdn.ampproject.org';
 const RUNTIME_METADATA_PATH = '/rtv/metadata';
+const VERSION_TXT_PATH = '/version.txt';
 
 /**
- * Queries https://cdn.ampproject.org/rtv/metadata for the latest AMP runtime version. Uses a
+ * @typedef {number} ReleaseType
+ */
+
+/**
+ * Release type "enumeration"
+ *
+ * @enum {ReleaseType}
+ */
+const ReleaseType = {
+  canary: 0,
+  prod: 1,
+  lts: 2,
+};
+
+/**
+ * Queries <host>/rtv/metadata for the latest AMP runtime version. If version is not available from
+ * this endpoint, falls back to <host>/version.txt and manually prepends config code. Uses a
  * stale-while-revalidate caching strategy to avoid refreshing the version.
  *
- * More details: https://cdn.ampproject.org/rtv/metadata returns the following metadata:
+ * /rtv/metadata endpoint details:
  *
  * <pre>
  * {
- *    "ampRuntimeVersion": "CURRENT_PROD",
- *    "ampCssUrl": "https://cdn.ampproject.org/rtv/CURRENT_PROD/v0.css",
- *    "canaryPercentage": "0.1",
- *    "diversions": [
- *      "CURRENT_OPTIN",
- *      "CURRENT_1%",
- *      "CURRENT_CONTROL"
- *    ]
- *  }
- *  </pre>
+ *   "ampRuntimeVersion": "CURRENT_PROD",
+ *   "ampCssUrl": "https://cdn.ampproject.org/rtv/CURRENT_PROD/v0.css",
+ *   "canaryPercentage": "0.1",
+ *   "diversions": [
+ *     "CURRENT_OPTIN",
+ *     "CURRENT_1%",
+ *     "CURRENT_CONTROL"
+ *   ],
+ *   "ltsRuntimeVersion": "CURRENT_LTS",
+ *   "ltsCssUrl": "https://cdn.ampproject.org/rtv/CURRENT_LTS/v0.css"
+ * }
+ * </pre>
  *
- *  where:
+ * where:
  *
- *  <ul>
- *    <li> CURRENT_OPTIN: is when you go to https://cdn.ampproject.org/experiments.html and toggle "dev-channel". It's the earliest possible time to get new code.</li>
- *    <li> CURRENT_1%: 1% is the same code as opt-in that we're now comfortable releasing to 1% of the population.</li>
- *    <li> CURRENT_CONTROL is the same thing as production, but with a different URL. This is to compare experiments against, since prod's immutable caching would affect metrics.</li>
- *  </ul>
+ * <ul>
+ *   <li> CURRENT_OPTIN: is when you go to https://cdn.ampproject.org/experiments.html and toggle "dev-channel". It's the earliest possible time to get new code.</li>
+ *   <li> CURRENT_1%: 1% is the same code as opt-in that we're now comfortable releasing to 1% of the population.</li>
+ *   <li> CURRENT_CONTROL is the same thing as production, but with a different URL. This is to compare experiments against, since prod's immutable caching would affect metrics.</li>
+ * </ul>
  */
 class RuntimeVersion {
   constructor(fetch) {
@@ -56,49 +75,161 @@ class RuntimeVersion {
    * Returns the version of the current AMP runtime release. Pass
    * <code>{canary: true}</code> to get the latest canary version.
    *
-   * @param {Object} options - the options.
-   * @param {bool} options.canary - true if canary should be returned.
+   * @param {object} options - the options.
+   * @param {boolean} options.canary - true if canary should be returned.
    * @param {string} options.ampUrlPrefix - the domain & path to an AMP runtime.
    * @returns {Promise<string>} a promise containing the current version.
    */
   async currentVersion(options = {}) {
-    let runtimeMetaUrl = AMP_CACHE_HOST + RUNTIME_METADATA_PATH;
-    if (options.ampUrlPrefix) {
-      const customMetaUrl = options.ampUrlPrefix.replace(/\/$/, '') + RUNTIME_METADATA_PATH;
-      // Check whether ampUrlPrefix is absolute since relative paths are allowed
-      // by optimizer
-      if (this.isAbsoluteUrl_(customMetaUrl)) {
-        runtimeMetaUrl = customMetaUrl;
-      } else {
-        log.warn(
-          'ampUrlPrefix is not an absolute URL. Falling back to https://cdn.ampproject.org.'
-        );
-      }
+    if (options.ampUrlPrefix && !this.isAbsoluteUrl_(options.ampUrlPrefix)) {
+      throw new Error('host must be an absolute URL');
     }
-    const response = await this.fetch_(runtimeMetaUrl);
-    const data = await response.json();
-    let version;
+    if (options.ampUrlPrefix && options.lts) {
+      throw new Error('lts flag is not compatible with custom host');
+    }
+    if (options.canary && options.lts) {
+      throw new Error('lts flag is not compatible with canary flag');
+    }
+
+    let releaseType = ReleaseType.prod;
     if (options.canary) {
-      version = data.diversions[0];
-      log.debug('canary version', version);
-    } else {
-      version = data.ampRuntimeVersion;
-      log.debug('prod version', version);
+      releaseType = ReleaseType.canary;
+    } else if (options.lts) {
+      releaseType = ReleaseType.lts;
     }
-    return this.padVersionString_(version);
+
+    const host = options.ampUrlPrefix ? options.ampUrlPrefix.replace(/\/$/, '') : AMP_CACHE_HOST;
+
+    let rtv = await this.getVersionFromRuntimeMetadata_(host, releaseType);
+    if (!rtv) {
+      rtv = await this.getVersionFromVersionTxt_(host, releaseType);
+    }
+
+    return rtv;
   }
 
   /* PRIVATE */
-  padVersionString_(version) {
-    return this.pad_(version, 15, 0);
+
+  /**
+   * Get runtime version from <host>/rtv/metadata
+   *
+   * @param {string} host - runtime host.
+   * @param {ReleaseType} releaseType - release type.
+   * @returns {Promise<string>} a promise containing the runtime version.
+   */
+  async getVersionFromRuntimeMetadata_(host, releaseType) {
+    const runtimeMetaUrl = host + RUNTIME_METADATA_PATH;
+    log.debug(`Fetching version from ${runtimeMetaUrl}`);
+
+    let response;
+    try {
+      response = await this.fetch_(runtimeMetaUrl);
+    } catch (ex) {}
+    if (!response || !response.ok) {
+      log.debug('RTV metadata endpoint could not be reached');
+      return;
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (ex) {
+      log.debug('RTV metadata JSON malformed');
+      return;
+    }
+
+    let rtv;
+    if (releaseType === ReleaseType.canary) {
+      if (
+        Array.isArray(data.diversions) &&
+        data.diversions[0] &&
+        data.diversions[0].startsWith(this.getRtvConfigCode_(releaseType))
+      ) {
+        rtv = data.diversions[0];
+      }
+      if (!rtv) {
+        log.debug('RTV metadata JSON malformed, canary version not in diversions array');
+      }
+    } else if (releaseType === ReleaseType.lts) {
+      rtv = data.ltsRuntimeVersion;
+      if (!rtv) {
+        log.debug('RTV metadata JSON malformed, lts version not in ltsRuntimeVersion');
+      }
+    } else if (releaseType === ReleaseType.prod) {
+      rtv = data.ampRuntimeVersion;
+      if (!rtv) {
+        log.debug('RTV metadata JSON malformed, production version not in ampRuntimeVersion');
+      }
+    }
+
+    return rtv;
   }
 
-  pad_(n, width, z) {
-    z = z || '0';
-    n = String(n);
-    return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
+  /**
+   * Get runtime version from <host>/version.txt, manually prepending config code
+   *
+   * @param {string} host - runtime host.
+   * @param {ReleaseType} releaseType - release type.
+   * @returns {Promise<string>} a promise containing the runtime version.
+   */
+  async getVersionFromVersionTxt_(host, releaseType) {
+    let versionTxtUrl = host + VERSION_TXT_PATH;
+    log.debug(`Falling back to ${versionTxtUrl}`);
+
+    let response;
+    try {
+      response = await this.fetch_(versionTxtUrl);
+    } catch (ex) {}
+    if (!response || !response.ok) {
+      log.debug('version.txt endpoint could not be reached');
+      return;
+    }
+
+    let version;
+    try {
+      version = (await response.text()).trim();
+      if (version !== encodeURIComponent(version)) {
+        throw new Error();
+      }
+    } catch (ex) {
+      log.debug('Version string malformed, not URL compatible');
+      return;
+    }
+
+    const rtv = this.getRtvConfigCode_(releaseType) + version;
+
+    // Verify rtv path exists
+    try {
+      versionTxtUrl = `${host}/rtv/${rtv}${VERSION_TXT_PATH}`;
+      response = await this.fetch_(versionTxtUrl);
+    } catch (ex) {}
+    if (!response || !response.ok) {
+      log.error('RTV could not be verified');
+      return;
+    }
+
+    return rtv;
   }
 
+  /**
+   * Get config code corresponding to release type
+   *
+   * @param {ReleaseType} releaseType - release type.
+   * @returns {string}
+   */
+  getRtvConfigCode_(releaseType) {
+    if (releaseType === ReleaseType.canary) {
+      return '00';
+    }
+    return '01';
+  }
+
+  /**
+   * Determine whether a URL is absolute.
+   *
+   * @param {string} url - URL to test.
+   * @returns {boolean}
+   */
   isAbsoluteUrl_(url) {
     try {
       new URL(url);

--- a/packages/runtime-version/lib/RuntimeVersion.js
+++ b/packages/runtime-version/lib/RuntimeVersion.js
@@ -121,9 +121,13 @@ class RuntimeVersion {
     let response;
     try {
       response = await this.fetch_(runtimeMetaUrl);
-    } catch (ex) {}
+    } catch (ex) {
+      // Avoid exception to give fallback mechanism getVersionFromVersionTxt_()
+      // a chance to lookup version, and to gracefully return 'undefined' if no
+      // version is ultimately found.
+    }
     if (!response || !response.ok) {
-      log.debug('RTV metadata endpoint could not be reached');
+      log.debug('RTV metadata endpoint did not respond with a successful status code');
       return;
     }
 
@@ -183,9 +187,11 @@ class RuntimeVersion {
     let response;
     try {
       response = await this.fetch_(versionTxtUrl);
-    } catch (ex) {}
+    } catch (ex) {
+      // Prefer gracefully returning 'undefined' version to throwing.
+    }
     if (!response || !response.ok) {
-      log.debug('version.txt endpoint could not be reached');
+      log.debug('version.txt endpoint did not respond with a successful status code');
       return;
     }
 

--- a/packages/runtime-version/spec/lib/RuntimeVersionSpec.js
+++ b/packages/runtime-version/spec/lib/RuntimeVersionSpec.js
@@ -78,37 +78,22 @@ describe('RuntimeVersion', () => {
     });
     it('supports getting release version from host without metadata endpoint', (done) => {
       const host = 'https://example.com/amp';
-      const rtv = defaultMetadata.ampRuntimeVersion;
-      const version = rtv.substring(2);
+      const version = defaultMetadata.ampRuntimeVersion.substring(2);
       fetchMock.get(`${host}/version.txt`, version);
-      fetchMock.get(`${host}/rtv/${rtv}/version.txt`, version);
       runtimeVersion.currentVersion({ampUrlPrefix: host}).then((rtv) => {
-        expect(rtv).toBe(rtv);
+        expect(rtv).toBe(defaultMetadata.ampRuntimeVersion);
         done();
       });
     });
-    it('supports getting canary version from host without metadata endpoint', (done) => {
-      const host = 'https://example.com/amp';
-      const rtv = defaultMetadata.diversions[0];
-      const version = rtv.substring(2);
-      fetchMock.get(`${host}/version.txt`, version);
-      fetchMock.get(`${host}/rtv/${rtv}/version.txt`, version);
-      runtimeVersion.currentVersion({ampUrlPrefix: host, canary: true}).then((rtv) => {
-        expect(rtv).toBe(rtv);
+    it('gracefully returns undefined if version not found', (done) => {
+      runtimeVersion.currentVersion().then((rtv) => {
+        expect(rtv).toBeUndefined();
         done();
       });
     });
     it('does not support simultaneous use of lts and canary flags', (done) => {
       fetchMock.get(`${defaultHost}/rtv/metadata`, defaultMetadata);
       runtimeVersion.currentVersion({canary: true, lts: true}).catch((error) => {
-        expect(error.message).toMatch(/not compatible/);
-        done();
-      });
-    });
-    it('does not support simultaneous use of lts flag and custom host', (done) => {
-      const host = 'https://example.com/amp';
-      fetchMock.get(`${host}/rtv/metadata`, defaultMetadata);
-      runtimeVersion.currentVersion({ampUrlPrefix: host, lts: true}).catch((error) => {
         expect(error.message).toMatch(/not compatible/);
         done();
       });

--- a/packages/runtime-version/spec/lib/RuntimeVersionSpec.js
+++ b/packages/runtime-version/spec/lib/RuntimeVersionSpec.js
@@ -15,33 +15,109 @@
  */
 
 const RuntimeVersion = require('../../lib/RuntimeVersion.js');
-const fetch = require('node-fetch');
+const fetchMock = require('fetch-mock').sandbox();
+
+const defaultHost = 'https://cdn.ampproject.org';
+const defaultMetadata = {
+  ampRuntimeVersion: '012004030010070',
+  diversions: ['002004012111560'],
+  ltsRuntimeVersion: '012002251816300',
+};
 
 describe('RuntimeVersion', () => {
-  const runtimeVersion = new RuntimeVersion(fetch);
+  let runtimeVersion;
+
+  beforeEach(() => {
+    runtimeVersion = new RuntimeVersion(fetchMock);
+
+    // Set unmatched fetch-mock responses to "not found"
+    fetchMock.catch(404);
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+  });
 
   describe('currentVersion', () => {
     it('returns release version by default', (done) => {
-      runtimeVersion.currentVersion().then((version) => {
-        expect(version).toMatch(/[0-9]+/);
+      fetchMock.get(`${defaultHost}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion().then((rtv) => {
+        expect(rtv).toBe(defaultMetadata.ampRuntimeVersion);
         done();
       });
     });
     it('returns canary version if specified via option', (done) => {
-      runtimeVersion.currentVersion({canary: true}).then((version) => {
-        expect(version).toMatch(/[0-9]+/);
+      fetchMock.get(`${defaultHost}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({canary: true}).then((rtv) => {
+        expect(rtv).toBe(defaultMetadata.diversions[0]);
         done();
       });
     });
-    it('pads release version to 15 chars', (done) => {
-      runtimeVersion.currentVersion().then((version) => {
-        expect(version.length).toBe(15);
+    it('returns lts version if specified via option', (done) => {
+      fetchMock.get(`${defaultHost}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({lts: true}).then((rtv) => {
+        expect(rtv).toBe(defaultMetadata.ltsRuntimeVersion);
         done();
       });
     });
-    it('pads canary version to 15 chars', (done) => {
-      runtimeVersion.currentVersion({canary: true}).then((version) => {
-        expect(version.length).toBe(15);
+    it('supports getting release version from alternate host', (done) => {
+      const host = 'https://example.com/amp';
+      fetchMock.get(`${host}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({ampUrlPrefix: host}).then((rtv) => {
+        expect(rtv).toBe(defaultMetadata.ampRuntimeVersion);
+        done();
+      });
+    });
+    it('supports getting canary version from alternate host', (done) => {
+      const host = 'https://example.com/amp';
+      fetchMock.get(`${host}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({ampUrlPrefix: host, canary: true}).then((rtv) => {
+        expect(rtv).toBe(defaultMetadata.diversions[0]);
+        done();
+      });
+    });
+    it('supports getting release version from host without metadata endpoint', (done) => {
+      const host = 'https://example.com/amp';
+      const rtv = defaultMetadata.ampRuntimeVersion;
+      const version = rtv.substring(2);
+      fetchMock.get(`${host}/version.txt`, version);
+      fetchMock.get(`${host}/rtv/${rtv}/version.txt`, version);
+      runtimeVersion.currentVersion({ampUrlPrefix: host}).then((rtv) => {
+        expect(rtv).toBe(rtv);
+        done();
+      });
+    });
+    it('supports getting canary version from host without metadata endpoint', (done) => {
+      const host = 'https://example.com/amp';
+      const rtv = defaultMetadata.diversions[0];
+      const version = rtv.substring(2);
+      fetchMock.get(`${host}/version.txt`, version);
+      fetchMock.get(`${host}/rtv/${rtv}/version.txt`, version);
+      runtimeVersion.currentVersion({ampUrlPrefix: host, canary: true}).then((rtv) => {
+        expect(rtv).toBe(rtv);
+        done();
+      });
+    });
+    it('does not support simultaneous use of lts and canary flags', (done) => {
+      fetchMock.get(`${defaultHost}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({canary: true, lts: true}).catch((error) => {
+        expect(error.message).toMatch(/not compatible/);
+        done();
+      });
+    });
+    it('does not support simultaneous use of lts flag and custom host', (done) => {
+      const host = 'https://example.com/amp';
+      fetchMock.get(`${host}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({ampUrlPrefix: host, lts: true}).catch((error) => {
+        expect(error.message).toMatch(/not compatible/);
+        done();
+      });
+    });
+    it('does not support relative URL for custom host', (done) => {
+      const host = '/amp';
+      fetchMock.get(`${host}/rtv/metadata`, defaultMetadata);
+      runtimeVersion.currentVersion({ampUrlPrefix: host}).catch((error) => {
+        expect(error.message).toMatch(/absolute URL/);
         done();
       });
     });


### PR DESCRIPTION
* Support `lts` flag, both as an argument to `.getVersion()` and as a
  CLI argument.
* Fall back to `/version.txt` if `/rtv/metadata` is not available.
  This feature is only available for standard `prod` lookups, it
  is not used when a `canary` or `lts` release is requested. This
  lessens the requirements for self-hosting the runtime.
* Remove RTV padding. There's little chance that padding
  the result is going to ever result in a valid RTV.
* Gracefully return `undefined` (or empty string in CLI) when version
  is not available.
* Update test spec to use fetch-mock so network requests are not made.