### PR TITLE
Adds types to module

### DIFF
--- a/packages/cache-url/index.d.ts
+++ b/packages/cache-url/index.d.ts
@@ -1,0 +1,9 @@
+export class AmpToolboxCacheUrl {
+  static createCacheUrl(
+    domainSuffix: string,
+    url: string
+  ): Promise<string>;
+  static createCurlsSubdomain(
+    url: string,
+  ): Promise<string>;
+}

--- a/packages/cache-url/package.json
+++ b/packages/cache-url/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.0",
   "description": "Transform canonical URLs into AMP Cache URLs",
   "main": "dist/amp-toolbox-cache-url.cjs.js",
+  "types": "index.d.ts",
   "module": "dist/amp-toolbox-cache-url.esm.js",
   "browser": "dist/amp-toolbox-cache-url.umd.js",
   "scripts": {


### PR DESCRIPTION
Adding types to the package (similar to the [viewer messaging module](https://github.com/ampproject/amphtml/blob/b6313e372fdd1298928e2417dcc616b03288e051/extensions/amp-viewer-integration/0.1/messaging/messaging.d.ts)) so that it can be used in the AMPHTML repo successfully.

Currently [adding](https://github.com/ampproject/amphtml/pull/27589/files) this module to the AMPHTL repo throws [errors](https://travis-ci.org/github/ampproject/amphtml/jobs/671859658#L451-L455) since there are no type declarations.

Requirement for https://github.com/ampproject/amphtml/issues/27588 and https://github.com/ampproject/amphtml/pull/27593

/cc @sebastianbenz 

