### PR TITLE
runtime-fetch: Prepare for broader amp-geo subdivision support

### DIFF
--- a/packages/runtime-fetch/lib/DownloadRuntime.js
+++ b/packages/runtime-fetch/lib/DownloadRuntime.js
@@ -323,7 +323,7 @@ class DownloadRuntime {
     // hotpatch before saving. Otherwise, stream the file directly to disk.
     if (/amp-geo-([\d.]+|latest)\.m?js/.test(filepath)) {
       const text = (await res.text()).replace(
-        / {28}|[a-z]{2} {26}|[a-z]{2} [a-z]{2}-[a-z]{2} {20}/i,
+        / {28}|[a-z]{2} {26}|[a-z]{2} [a-z]{2}-[a-z0-9]{1,3} {19,21}/i,
         '{{AMP_ISO_COUNTRY_HOTPATCH}}'
       );
       wstream.write(text, wstream.close.bind(wstream));

--- a/packages/runtime-fetch/spec/lib/DownloadRuntimeSpec.js
+++ b/packages/runtime-fetch/spec/lib/DownloadRuntimeSpec.js
@@ -33,6 +33,7 @@ const fakeFiles = {
   'v0/amp-geo-0.1.js': 'd=/^(\\w{2})?\\s*/.exec("                            ")',
   'v0/amp-geo-0.1.mjs': 'd=/^(\\w{2})?\\s*/.exec("us                          ")',
   'v0/amp-geo-latest.js': 'd=/^(\\w{2})?\\s*/.exec("us us-ca                    ")',
+  'v0/amp-geo-latest.mjs': 'd=/^(\\w{2})?\\s*/.exec("fj fj-w                     ")',
   'v0/examples/version.txt': defaultVersion,
 };
 fakeFiles['files.txt'] = Object.keys(fakeFiles).join('\n');


### PR DESCRIPTION
ISO 3166-2 country-subdivision code allows between 1-3 alphanumeric
characters in the subdivision part. While only `us-ca` is supported as of
today, go ahead an prepare for extended support now.