### PR TITLE
runtime-fetch: Fix incorrect geo regex

### DIFF
--- a/packages/runtime-fetch/lib/DownloadRuntime.js
+++ b/packages/runtime-fetch/lib/DownloadRuntime.js
@@ -323,7 +323,7 @@ class DownloadRuntime {
     // hotpatch before saving. Otherwise, stream the file directly to disk.
     if (/amp-geo-([\d.]+|latest)\.m?js/.test(filepath)) {
       const text = (await res.text()).replace(
-        /[a-z]{2}(?:-[a-z0-9]{2} {23}| {26})/i,
+        / {28}|[a-z]{2} {26}|[a-z]{2} [a-z]{2}-[a-z]{2} {20}/i,
         '{{AMP_ISO_COUNTRY_HOTPATCH}}'
       );
       wstream.write(text, wstream.close.bind(wstream));

--- a/packages/runtime-fetch/spec/lib/DownloadRuntimeSpec.js
+++ b/packages/runtime-fetch/spec/lib/DownloadRuntimeSpec.js
@@ -30,8 +30,9 @@ const defaultHost = 'https://cdn.ampproject.org';
 const fakeFiles = {
   'files.txt': '',
   'version.txt': defaultVersion,
-  'v0/amp-geo-0.1.js': 'd=/^(\\w{2})?\\s*/.exec("us                          ")',
-  'v0/amp-geo-0.1.mjs': 'd=/^(\\w{2})?\\s*/.exec("us-ca                       ")',
+  'v0/amp-geo-0.1.js': 'd=/^(\\w{2})?\\s*/.exec("                            ")',
+  'v0/amp-geo-0.1.mjs': 'd=/^(\\w{2})?\\s*/.exec("us                          ")',
+  'v0/amp-geo-latest.js': 'd=/^(\\w{2})?\\s*/.exec("us us-ca                    ")',
   'v0/examples/version.txt': defaultVersion,
 };
 fakeFiles['files.txt'] = Object.keys(fakeFiles).join('\n');
@@ -146,8 +147,9 @@ describe('DownloadRuntime', () => {
 
     it('reverts amp-geo hotpatching', (done) => {
       const ampGeoFilePaths = [
-        path.join(options.dest, 'rtv', defaultRtv, 'v0', 'amp-geo-0.1.js'), // country
-        path.join(options.dest, 'rtv', defaultRtv, 'v0', 'amp-geo-0.1.mjs'), // subdivision
+        path.join(options.dest, 'rtv', defaultRtv, 'v0', 'amp-geo-0.1.js'), // indeterminate
+        path.join(options.dest, 'rtv', defaultRtv, 'v0', 'amp-geo-0.1.mjs'), // country
+        path.join(options.dest, 'rtv', defaultRtv, 'v0', 'amp-geo-latest.js'), // country + subdivision
       ];
       Object.keys(mockResponses).forEach((filename) => {
         fetchMock.get(`${defaultHost}/${filename}`, mockResponses[filename]);


### PR DESCRIPTION
The regex used to reverse the `{{AMP_ISO_COUNTRY_HOTPATCH}}` patch had two
problems:

- Did not take into account case when country is not found (all spaces)
- Incorrect subdivision pattern

These are the realistic hotpatch examples that can be found in the wild
today:
```
"                            "
"us                          "
"us us-ca                    "
```