### PR TITLE
Add module/no-module support

### DIFF
--- a/packages/optimizer/lib/transformers/RewriteAmpUrls.js
+++ b/packages/optimizer/lib/transformers/RewriteAmpUrls.js
@@ -68,6 +68,9 @@ class RewriteAmpUrls {
     while (node) {
       if (node.tagName === 'script' && this._usesAmpCacheUrl(node.attribs.src)) {
         node.attribs.src = this._replaceUrl(node.attribs.src, host);
+        if (params.experimentEsm) {
+          this._addEsm(node, node.attribs.src.endsWith('v0.js'));
+        }
         referenceNode = this._addPreload(head, referenceNode, node.attribs.src, 'script');
       } else if (
         node.tagName === 'link' &&
@@ -99,6 +102,31 @@ class RewriteAmpUrls {
 
   _replaceUrl(url, ampUrlPrefix) {
     return ampUrlPrefix + url.substring(AMP_CACHE_HOST.length);
+  }
+
+  _addEsm(scriptNode, preload) {
+    const esmScriptUrl = scriptNode.attribs.src.replace(/\.js$/, '.mjs');
+    if (preload) {
+      const preload = createElement('link', {
+        as: 'script',
+        crossorigin: 'anonymous',
+        href: esmScriptUrl,
+        rel: 'preload',
+      });
+      insertBefore(scriptNode.parent, preload, scriptNode);
+    }
+    const nomoduleNode = createElement('script', {
+      async: '',
+      nomodule: '',
+      src: scriptNode.attribs.src,
+    });
+    insertBefore(scriptNode.parent, nomoduleNode, scriptNode);
+
+    scriptNode.attribs.type = 'module';
+    // Without crossorigin=anonymous browser loads the script twice because
+    // of preload.
+    scriptNode.attribs.crossorigin = 'anonymous';
+    scriptNode.attribs.src = esmScriptUrl;
   }
 
   _addPreload(parent, node, href, type) {

--- a/packages/optimizer/lib/transformers/RewriteAmpUrls.js
+++ b/packages/optimizer/lib/transformers/RewriteAmpUrls.js
@@ -55,6 +55,9 @@ const {calculateHost} = require('../RuntimeHostHelper');
  * push for CDNs (see https://www.w3.org/TR/preload/#server-push-(http/2)).
  */
 class RewriteAmpUrls {
+  constructor(config) {
+    this.esmModulesEnabled = config.experimentEsm;
+  }
   transform(root, params) {
     const html = firstChildByTag(root, 'html');
     const head = firstChildByTag(html, 'head');
@@ -68,7 +71,7 @@ class RewriteAmpUrls {
     while (node) {
       if (node.tagName === 'script' && this._usesAmpCacheUrl(node.attribs.src)) {
         node.attribs.src = this._replaceUrl(node.attribs.src, host);
-        if (params.experimentEsm) {
+        if (this.esmModulesEnabled) {
           this._addEsm(node, node.attribs.src.endsWith('v0.js'));
         }
         referenceNode = this._addPreload(head, referenceNode, node.attribs.src, 'script');

--- a/packages/optimizer/spec/end-to-end/EndToEndSpec.js
+++ b/packages/optimizer/spec/end-to-end/EndToEndSpec.js
@@ -21,8 +21,9 @@ const {DomTransformer, TRANSFORMATIONS_PAIRED_AMP} = require('../../lib/DomTrans
 const fetchMock = require('fetch-mock');
 const fetch = fetchMock
   .sandbox()
-  .mock('https://cdn.ampproject.org/rtv/123456789000000/v0.css', '/* v0.css */')
-  .mock('https://cdn.ampproject.org/v0.css', '/* v0.css */');
+  .mock('https://cdn.ampproject.org/rtv/123456789000000/v0.css', '/* ampproject.org/rtv v0.css */')
+  .mock('https://example.com/amp/rtv/123456789000000/v0.css', '/* example.com v0.css */')
+  .mock('https://cdn.ampproject.org/v0.css', '/* ampproject.org v0.css */');
 
 createSpec({
   name: 'End-to-End: AMP First',

--- a/packages/optimizer/spec/end-to-end/body-only/expected_output.valid.html
+++ b/packages/optimizer/spec/end-to-end/body-only/expected_output.valid.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html amp i-amphtml-layout i-amphtml-no-boilerplate transformed="self;v=1">
 <head>
-  <meta data-auto charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* v0.css */</style>
+  <meta data-auto charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* ampproject.org/rtv v0.css */</style>
   <meta data-auto name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script data-auto async src="https://cdn.ampproject.org/v0.js"></script>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.html
@@ -1,17 +1,17 @@
 <!doctype html>
 <html i-amphtml-layout i-amphtml-no-boilerplate transformed="self;v=1">
 <head>
-  <meta charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* v0.css */</style>
+  <meta charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* example.com v0.css */</style>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
-  <link rel="preload" href="/amp/rtv/123456789000000/v0.js" as="script">
-  <meta name="runtime-host" content="/amp">
+  <link rel="preload" href="https://example.com/amp/rtv/123456789000000/v0.js" as="script">
+  <meta name="runtime-host" content="https://example.com/amp">
   <meta name="amp-geo-api" content="/geo">
-  <script async src="/amp/rtv/123456789000000/v0.js"></script>
-  <script async custom-element="amp-experiment" src="/amp/rtv/123456789000000/v0/amp-experiment-0.1.js"></script>
-  <script async custom-element="amp-video" src="/amp/rtv/123456789000000/v0/amp-video-0.1.js"></script>
-  <script async custom-template="amp-mustache" src="/amp/rtv/123456789000000/v0/amp-mustache-0.1.js"></script>
+  <script async src="https://example.com/amp/rtv/123456789000000/v0.js"></script>
+  <script async custom-element="amp-experiment" src="https://example.com/amp/rtv/123456789000000/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://example.com/amp/rtv/123456789000000/v0/amp-video-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://example.com/amp/rtv/123456789000000/v0/amp-mustache-0.1.js"></script>
   <link rel="canonical" href="self.html"><style amp-custom>h1{margin:16px}</style>
-  <link rel="amphtml" href="https://example.com/amp-version.html">
+  <link rel="amphtml" href="/amp-version.html">
 </head>
 <body>
   <h1>Hello, AMP world!</h1>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.valid.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.valid.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html ⚡ i-amphtml-layout i-amphtml-no-boilerplate transformed="self;v=1">
 <head>
-  <meta charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* v0.css */</style>
+  <meta charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* ampproject.org/rtv v0.css */</style>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/packages/optimizer/spec/end-to-end/hello-world/input.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/input.html
@@ -1,8 +1,8 @@
 <!--
 {
-  "ampUrlPrefix": "/amp",
+  "ampUrlPrefix": "https://example.com/amp",
   "ampRuntimeVersion": "123456789000000",
-  "ampUrl": "https://example.com/amp-version.html",
+  "ampUrl": "/amp-version.html",
   "geoApiUrl": "/geo"
 }
 -->

--- a/packages/optimizer/spec/end-to-end/markdown/expected_output.valid.html
+++ b/packages/optimizer/spec/end-to-end/markdown/expected_output.valid.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html amp i-amphtml-layout i-amphtml-no-boilerplate transformed="self;v=1">
 <head>
-  <meta data-auto charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* v0.css */</style>
+  <meta data-auto charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* ampproject.org/rtv v0.css */</style>
   <meta data-auto name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script data-auto async src="https://cdn.ampproject.org/v0.js"></script>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/expected_output.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
+  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
+  <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
+  <link href="https://example.com/favicon.ico" rel="icon">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/input.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/input.html
@@ -1,8 +1,3 @@
-<!--
-{
-  "experimentEsm": true
-}
--->
 <!doctype html>
 <html ⚡>
 <head>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/input.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/input.html
@@ -1,0 +1,16 @@
+<!--
+{
+  "experimentEsm": true
+}
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element=amp-experiment src=https://cdn.ampproject.org/v0/amp-experiment-0.1.js></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel=stylesheet href=https://cdn.ampproject.org/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_geoapi/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_geoapi/expected_output.html
@@ -2,12 +2,14 @@
 <html ⚡>
 <head>
   <meta name="amp-geo-api" content="/geo">
-  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
+  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_lts/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_lts/expected_output.html
@@ -1,12 +1,14 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js"></script>
-  <script async src="https://cdn.ampproject.org/lts/v0.js"></script>
+  <script async nomodule src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/lts/v0.mjs" rel="preload">
+  <script async nomodule src="https://cdn.ampproject.org/lts/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/lts/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/lts/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="https://cdn.ampproject.org/lts/v0.js" as="script">
   <link rel="preload" href="https://cdn.ampproject.org/lts/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_preloads/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_preloads/expected_output.html
@@ -1,12 +1,14 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
+  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_runtime_version/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_runtime_version/expected_output.html
@@ -1,12 +1,14 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
-  <script async src="https://cdn.ampproject.org/rtv/001515617716922/v0.js"></script>
+  <script async nomodule src="https://cdn.ampproject.org/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/rtv/001515617716922/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/rtv/001515617716922/v0.mjs" rel="preload">
+  <script async nomodule src="https://cdn.ampproject.org/rtv/001515617716922/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/rtv/001515617716922/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/rtv/001515617716922/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="https://cdn.ampproject.org/rtv/001515617716922/v0.js" as="script">
   <link rel="preload" href="https://cdn.ampproject.org/rtv/001515617716922/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/config.json
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/config.json
@@ -1,0 +1,3 @@
+{
+  "experimentEsm": true
+}

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
@@ -2,12 +2,14 @@
 <html ⚡>
 <head>
   <meta name="runtime-host" content="/amp">
-  <script async custom-element="amp-experiment" src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
-  <script async src="/amp/rtv/001515617716922/v0.js"></script>
+  <script async nomodule src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="/amp/rtv/001515617716922/v0.mjs" rel="preload">
+  <script async nomodule src="/amp/rtv/001515617716922/v0.js"></script>
+  <script async src="/amp/rtv/001515617716922/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="/amp/rtv/001515617716922/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="/amp/rtv/001515617716922/v0.js" as="script">
   <link rel="preload" href="/amp/rtv/001515617716922/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
@@ -2,12 +2,14 @@
 <html ⚡>
 <head>
   <meta name="runtime-host" content="/amp">
-  <script async custom-element="amp-experiment" src="/amp/v0/amp-experiment-0.1.js"></script>
-  <script async src="/amp/v0.js"></script>
+  <script async nomodule src="/amp/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-experiment" src="/amp/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link as="script" crossorigin="anonymous" href="/amp/v0.mjs" rel="preload">
+  <script async nomodule src="/amp/v0.js"></script>
+  <script async src="/amp/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="/amp/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="/amp/v0.js" as="script">
   <link rel="preload" href="/amp/v0.css" as="style">
 </head>
 <body></body>


### PR DESCRIPTION
This PR adds the experimental module/nomodule runtime loading support.
ESM module loading support can be added via the `experimentEsm=true`
parameter.