### PR TITLE
Add experimental image preloading support

### DIFF
--- a/packages/optimizer/lib/DomTransformer.js
+++ b/packages/optimizer/lib/DomTransformer.js
@@ -43,6 +43,8 @@ const TRANSFORMATIONS_AMP_FIRST = [
   // needs to run after ReorderHeadTransformer
   'RewriteAmpUrls',
   'GoogleFontsPreconnect',
+  // Detect hero image and preload link rel=preload
+  'PreloadHeroImage',
   'PruneDuplicateResourceHints',
   // Move keyframes into a separate style tag
   'SeparateKeyframes',
@@ -79,6 +81,8 @@ const TRANSFORMATIONS_PAIRED_AMP = [
   // needs to run after ReorderHeadTransformer
   'RewriteAmpUrls',
   'GoogleFontsPreconnect',
+  // Detect hero image and preload link rel=preload
+  'PreloadHeroImage',
   'PruneDuplicateResourceHints',
   'AddBlurryImagePlaceholders',
   'SeparateKeyframes',

--- a/packages/optimizer/lib/parseSrcSet.js
+++ b/packages/optimizer/lib/parseSrcSet.js
@@ -1,0 +1,307 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Credits: ported from https://github.com/ampproject/amphtml/blob/1098976cdb0bb73ad89f3287185df992bb29f69c/src/srcset.js
+ */
+
+/**
+ * A single source within a srcset. Only one: width or DPR can be specified at
+ * a time.
+ * @typedef {{
+ *   url: string,
+ *   width: (number|undefined),
+ *   dpr: (number|undefined)
+ * }}
+ */
+let SrcsetSourceDef;
+
+/**
+ * General grammar: (URL [NUM[w|x]],)*
+ * Example 1: "image1.png 100w, image2.png 50w"
+ * Example 2: "image1.png 2x, image2.png"
+ * Example 3: "image1,100w.png 100w, image2.png 50w"
+ */
+const srcsetRegex = /(\S+)(?:\s+(?:(-?\d+(?:\.\d+)?)([a-zA-Z]*)))?\s*(?:,|$)/g;
+
+/**
+ * Parses the text representation of srcset into Srcset object.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes.
+ * See http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-srcset.
+ * @param {string} s
+ * @return {!Srcset}
+ */
+function parseSrcset(s) {
+  const sources = [];
+  let match;
+  while ((match = srcsetRegex.exec(s))) {
+    const url = match[1];
+    let width, dpr;
+    if (match[2]) {
+      const type = match[3].toLowerCase();
+      if (type == 'w') {
+        width = parseInt(match[2], 10);
+      } else if (type == 'x') {
+        dpr = parseFloat(match[2]);
+      } else {
+        continue;
+      }
+    } else {
+      // If no "w" or "x" specified, we assume it's "1x".
+      dpr = 1;
+    }
+    sources.push({url, width, dpr});
+  }
+  return new Srcset(sources);
+}
+
+/**
+ * A srcset object contains one or more sources.
+ *
+ * There are two types of sources: width-based and DPR-based. Only one type
+ * of sources allowed to be specified within a single srcset. Depending on a
+ * usecase, the components are free to choose any source that best corresponds
+ * to the required rendering quality and network and CPU conditions. See
+ * "select" method for details on how this selection is performed.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes
+ */
+class Srcset {
+  /**
+   * @param {!Array<!SrcsetSourceDef>} sources
+   */
+  constructor(sources) {
+    assert(sources.length > 0, 'Srcset must have at least one source');
+    /** @private @const {!Array<!SrcsetSourceDef>} */
+    this.sources_ = sources;
+
+    // Only one type of source specified can be used - width or DPR.
+    let hasWidth = false;
+    let hasDpr = false;
+    for (let i = 0; i < sources.length; i++) {
+      const source = sources[i];
+      hasWidth = hasWidth || !!source.width;
+      hasDpr = hasDpr || !!source.dpr;
+    }
+    assert(!!(hasWidth ^ hasDpr), 'Srcset must have width or dpr sources, but not both');
+
+    // Source and assert duplicates.
+    sources.sort(hasWidth ? sortByWidth : sortByDpr);
+
+    /** @private @const {boolean} */
+    this.widthBased_ = hasWidth;
+  }
+
+  /**
+   * Performs selection for specified width and DPR. Here, width is the width
+   * in screen pixels and DPR is the device-pixel-ratio or pixel density of
+   * the device. Depending on the circumstances, such as low network conditions,
+   * it's possible to manipulate the result of this method by passing a lower
+   * DPR value.
+   *
+   * The source selection depends on whether this is width-based or DPR-based
+   * srcset.
+   *
+   * In a width-based source, the source's width is the physical width of a
+   * resource (e.g. an image). Depending on the provided DPR, this width is
+   * converted to the screen pixels as following:
+   *   pixelWidth = sourceWidth / DPR
+   *
+   * Then, the source closest to the requested "width" is selected using
+   * the "pixelWidth". The slight preference is given to the bigger sources to
+   * ensure the most optimal quality.
+   *
+   * In a DPR-based source, the source's DPR is used to return the source that
+   * is closest to the requested DPR.
+   *
+   * Based on
+   * http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-srcset.
+   * @param {number} width
+   * @param {number} dpr
+   * @return {string}
+   */
+  select(width, dpr) {
+    assert(width, 'width=%s', width);
+    assert(dpr, 'dpr=%s', dpr);
+    let index = 0;
+    if (this.widthBased_) {
+      index = this.selectByWidth_(width * dpr);
+    } else {
+      index = this.selectByDpr_(dpr);
+    }
+    return this.sources_[index].url;
+  }
+
+  /**
+   * @param {number} width
+   * @return {number}
+   * @private
+   */
+  selectByWidth_(width) {
+    const sources = this.sources_;
+    let minIndex = 0;
+    let minScore = Infinity;
+    let minWidth = Infinity;
+
+    for (let i = 0; i < sources.length; i++) {
+      const sWidth = sources[i].width;
+      const score = Math.abs(sWidth - width);
+
+      // Select the one that is closer with a slight preference toward larger
+      // widths. If smaller size is closer, enforce minimum ratio to ensure
+      // image isn't too distorted.
+      if (score <= minScore * 1.1 || width / minWidth > 1.2) {
+        minIndex = i;
+        minScore = score;
+        minWidth = sWidth;
+      } else {
+        break;
+      }
+    }
+    return minIndex;
+  }
+
+  /**
+   * @param {number} dpr
+   * @return {number}
+   * @private
+   */
+  selectByDpr_(dpr) {
+    const sources = this.sources_;
+    let minIndex = 0;
+    let minScore = Infinity;
+
+    for (let i = 0; i < sources.length; i++) {
+      const score = Math.abs(sources[i].dpr - dpr);
+      if (score <= minScore) {
+        minIndex = i;
+        minScore = score;
+      } else {
+        break;
+      }
+    }
+    return minIndex;
+  }
+
+  /**
+   * Returns all URLs in the srcset.
+   * @return {!Array<string>}
+   */
+  getUrls() {
+    return this.sources_.map((s) => s.url);
+  }
+
+  /**
+   * Reconstructs the string expression for this srcset.
+   * @param {function(string):string=} opt_mapper
+   * @return {string}
+   */
+  stringify(opt_mapper) {
+    const res = [];
+    const sources = this.sources_;
+    for (let i = 0; i < sources.length; i++) {
+      const source = sources[i];
+      let src = source.url;
+      if (opt_mapper) {
+        src = opt_mapper(src);
+      }
+      if (this.widthBased_) {
+        src += ` ${source.width}w`;
+      } else {
+        src += ` ${source.dpr}x`;
+      }
+      res.push(src);
+    }
+    return res.join(', ');
+  }
+}
+
+/**
+ * Sorts by width
+ *
+ * @param {number} s1
+ * @param {number} s2
+ * @return {number}
+ */
+function sortByWidth(s1, s2) {
+  assert(s1.width != s2.width, 'Duplicate width: %s', s1.width);
+  return s1.width - s2.width;
+}
+
+/**
+ * Sorts by dpr
+ *
+ * @param {!Object} s1
+ * @param {!Object} s2
+ * @return {number}
+ */
+function sortByDpr(s1, s2) {
+  assert(s1.dpr != s2.dpr, 'Duplicate dpr: %s', s1.dpr);
+  return s1.dpr - s2.dpr;
+}
+
+function assert(shouldBeTrueish, opt_message, ...var_args) {
+  let firstElement;
+  if (!shouldBeTrueish) {
+    const message = opt_message || 'Assertion failed';
+    const splitMessage = message.split('%s');
+    const first = splitMessage.shift();
+    let formatted = first;
+    const messageArray = [];
+    let i = 2;
+    pushIfNonEmpty(messageArray, first);
+    while (splitMessage.length > 0) {
+      const nextConstant = splitMessage.shift();
+      const val = arguments[i++];
+      if (val && val.tagName) {
+        firstElement = val;
+      }
+      messageArray.push(val);
+      pushIfNonEmpty(messageArray, nextConstant.trim());
+      formatted += stringOrElementString(val) + nextConstant;
+    }
+    const e = new Error(formatted);
+    e.fromAssert = true;
+    e.associatedElement = firstElement;
+    e.messageArray = messageArray;
+    throw e;
+  }
+  return shouldBeTrueish;
+}
+
+/**
+ * @param {string|!Element} val
+ * @return {string}
+ */
+const stringOrElementString = (val) => /** @type {string} */ elementStringOrPassthru(val);
+
+/**
+ * @param {*} val
+ * @return {*}
+ */
+function elementStringOrPassthru(val) {
+  // Do check equivalent to `val instanceof Element` without cross-window bug
+  if (val && val.nodeType == 1) {
+    return val.tagName.toLowerCase() + (val.id ? '#' + val.id : '');
+  }
+  return val;
+}
+
+function pushIfNonEmpty(array, val) {
+  if (val != '') {
+    array.push(val);
+  }
+}
+
+module.exports = parseSrcset;

--- a/packages/optimizer/lib/transformers/PreloadHeroImage.js
+++ b/packages/optimizer/lib/transformers/PreloadHeroImage.js
@@ -155,10 +155,7 @@ class PreloadHeroImage {
 
     if (!width && !height) {
       if (layout === 'fill') {
-        console.log('getting dim parent', this.nodeDimensionsFromParent(ampImg));
-        const dim = this.nodeDimensionsFromParent(ampImg);
-        width = dim.width;
-        height = dim.height;
+        ({width, height} = this.nodeDimensionsFromParent(ampImg));
       } else {
         return null;
       }

--- a/packages/optimizer/lib/transformers/PreloadHeroImage.js
+++ b/packages/optimizer/lib/transformers/PreloadHeroImage.js
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const {createElement, nextNode, insertAfter, firstChildByTag} = require('../NodeUtils');
+const {findMetaViewport} = require('../HtmlDomHelper');
+const parseSrcSet = require('../parseSrcSet');
+
+// Images smaller than 150px are considered tiny
+const TINY_IMG_THRESHOLD = 150;
+
+/**
+ * PreloadHeroImage - This transformer identifies a hero image or
+ * important images on the document and attaches <link rel="preload"> element.
+ *
+ * This transformer supports the following option:
+ *
+ * * `preloadHeroImage`: [true|false] - enables or disables hero image preloading. The default is `true`.
+ */
+class PreloadHeroImage {
+  constructor(config) {
+    this.log = config.log;
+    this.enabled = config.preloadHeroImage !== false && config.experimentPreloadHeroImage;
+    this.log.info('enabled', this.enabled);
+  }
+  async transform(root, params) {
+    if (!this.enabled || params.preloadHeroImage === false) {
+      return;
+    }
+    const html = firstChildByTag(root, 'html');
+    const head = firstChildByTag(html, 'head');
+    const body = firstChildByTag(html, 'body');
+    if (!body || !head) return;
+
+    const heroImage = this.findHeroImage(body);
+
+    if (!heroImage) {
+      return;
+    }
+    let referenceNode = findMetaViewport(head);
+
+    const preload = createElement('link', {
+      'rel': 'preload',
+      'href': heroImage.src,
+      'as': 'image',
+      'data-hero': '',
+    });
+    if (heroImage.srcset) {
+      try {
+        parseSrcSet(heroImage.srcset);
+        preload.attribs.srcset = heroImage.srcset;
+      } catch (err) {
+        this.log.warn(
+          `Invalid srcset '${heroImage.srcset}' for amp-img src '${heroImage.src}'`,
+          err.message
+        );
+      }
+    }
+    this.log.debug('Preloading hero image: ', heroImage.src);
+    insertAfter(head, preload, referenceNode);
+  }
+
+  findHeroImage(root) {
+    if (!root.tagName) {
+      return null;
+    }
+    // Ignore images inside templates
+    if (root.tagName === 'template') {
+      return null;
+    }
+
+    const layout = root.attribs ? root.attribs.layout : '';
+    if (layout === 'nodisplay') return null;
+
+    if (root.tagName === 'amp-img') {
+      return this.isCandidateImageForPreloading(root);
+    }
+    if (root.tagName === 'amp-video') {
+      return this.isCandidateVideoPosterImage(root);
+    }
+    if (root.tagName === 'amp-iframe' || root.tagName === 'amp-video-iframe') {
+      return this.isCandidateIframePlaceholderImage(root);
+    }
+
+    for (const child of root.children) {
+      const heroImage = this.findHeroImage(child);
+      if (heroImage) {
+        return heroImage;
+      }
+    }
+    return null;
+  }
+
+  // For a given <amp-video> node or any node that has poster attribute, and
+  // qualifies as hero image, returns the HeroImageSrcs.
+  isCandidateVideoPosterImage(ampVideo) {
+    const poster = ampVideo.attribs.poster;
+    if (!poster) return null;
+
+    const width = ampVideo.attribs.width;
+    const height = ampVideo.attribs.height;
+    if (this.isTinyNode(width, height)) {
+      return null;
+    }
+    return {src: poster, srcset: ''};
+  }
+
+  isCandidateIframePlaceholderImage(ampIframe) {
+    // Placeholder amp-img is required to preload image for iframe.
+    if (!ampIframe.children || ampIframe.children.length === 0) {
+      return null;
+    }
+
+    const width = ampIframe.attribs.width;
+    const height = ampIframe.attribs.height;
+
+    if (this.isTinyNode(width, height)) return null;
+
+    for (const child of ampIframe.children) {
+      if (child.tagName === 'amp-img' && child.attribs.placeholder) {
+        return {src: child.attribs.src, srcset: ''};
+      }
+    }
+    return null;
+  }
+
+  // Checks if node qualifies to be a hero image. Returns HeroImageSrcs if the
+  // node is a hero image. The hero image here can come from one of <amp-img>,
+  // <amp-video>, <amp-iframe>, <amp-video-iframe>.
+  isCandidateImageForPreloading(ampImg) {
+    const src = ampImg.attribs.src;
+    if (!src) {
+      return null;
+    }
+
+    let width = ampImg.attribs.width;
+    let height = ampImg.attribs.height;
+    const srcset = ampImg.attribs.srcset;
+
+    const layout = ampImg.attribs.layout;
+
+    if (!width && !height) {
+      if (layout === 'fill') {
+        console.log('getting dim parent', this.nodeDimensionsFromParent(ampImg));
+        const dim = this.nodeDimensionsFromParent(ampImg);
+        width = dim.width;
+        height = dim.height;
+      } else {
+        return null;
+      }
+    }
+    if (this.isTinyNode(width, height)) {
+      return null;
+    }
+    return {src, srcset};
+  }
+
+  // Any node with width or height less than 150 pixels.
+  isTinyNode(width, height) {
+    if (width <= 0 || height <= 0) return true;
+    return (width > 0 && width < TINY_IMG_THRESHOLD) || (height > 0 && height < TINY_IMG_THRESHOLD);
+  }
+
+  nodeDimensionsFromParent(node) {
+    while (node.parent) {
+      node = node.parent;
+      if (!node.attribs) {
+        continue;
+      }
+      const width = node.attribs.width;
+      const height = node.attribs.height;
+      if (!width && !height) {
+        continue;
+      }
+      return {width, height};
+    }
+    return {width: 0, height: 0};
+  }
+}
+
+/** @module PreloadHeroImage */
+module.exports = PreloadHeroImage;

--- a/packages/optimizer/spec/lib/parseSrcSetSpec.js
+++ b/packages/optimizer/spec/lib/parseSrcSetSpec.js
@@ -1,0 +1,259 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Credits: ported from https://github.com/ampproject/amphtml/blob/master/test/unit/test-srcset.js
+ */
+
+const parseSrcset = require('../../lib/parseSrcSet');
+
+describe('parseSrcset', () => {
+  function test(s, expected) {
+    const res = parseSrcset(s);
+    expect(res.sources_.length).toEqual(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      const r = res.sources_[i];
+      const e = expected[i];
+      expect(r.url).toEqual(e.url);
+      expect(r.width).toEqual(e.width);
+      expect(r.dpr).toEqual(e.dpr);
+    }
+  }
+
+  it('should accept single source, default to 1px', () => {
+    test(' \n image \n ', [{url: 'image', dpr: 1}]);
+  });
+
+  it('should ignore empty source', () => {
+    test(' \n image \n, ', [{url: 'image', dpr: 1}]);
+    test(' , \n image \n, ', [{url: 'image', dpr: 1}]);
+  });
+
+  it('should accept multiple sources, default to 1x', () => {
+    test(' \n image 2x \n\t, image2 \n', [
+      {url: 'image2', dpr: 1},
+      {url: 'image', dpr: 2},
+    ]);
+  });
+
+  it('should accept width-based sources', () => {
+    test(' \n image-100 100w\n, image 10w', [
+      {url: 'image', width: 10},
+      {url: 'image-100', width: 100},
+    ]);
+  });
+
+  it('should accept dpr-based sources', () => {
+    test(' \n image-x1.5 1.5x\n , image', [
+      {url: 'image', dpr: 1},
+      {url: 'image-x1.5', dpr: 1.5},
+    ]);
+  });
+
+  it('should tolerate other sources', () => {
+    test('image2x 2x, image2h 2h', [{url: 'image2x', dpr: 2}]);
+    test('image2x 2x, image2h 2H', [{url: 'image2x', dpr: 2}]);
+  });
+
+  it('should parse fractions', () => {
+    test('image-x1.5 1.5x', [{url: 'image-x1.5', dpr: 1.5}]);
+    test('image-x1.5 001x', [{url: 'image-x1.5', dpr: 1}]);
+    test('image-x1.5 1.00000x', [{url: 'image-x1.5', dpr: 1}]);
+    test('image-x1.5 0.1x', [{url: 'image-x1.5', dpr: 0.1}]);
+    test('image-x1.5 0000.1x', [{url: 'image-x1.5', dpr: 0.1}]);
+  });
+
+  it('should tolerate negatives', () => {
+    test('image-x1.5 -1.5x', [{url: 'image-x1.5', dpr: -1.5}]);
+    test('image-x1.5 -001x', [{url: 'image-x1.5', dpr: -1}]);
+  });
+
+  it('should accept several sources', () => {
+    test(' \n image1 100w\n , \n image2 50w\n , image3 10.5w', [
+      {url: 'image3', width: 10},
+      {url: 'image2', width: 50},
+      {url: 'image1', width: 100},
+    ]);
+  });
+
+  it('should accept commas in URLs', () => {
+    test(' \n image,1 100w\n , \n image,2 50w \n', [
+      {url: 'image,2', width: 50},
+      {url: 'image,1', width: 100},
+    ]);
+    test(' \n image,100w 100w\n , \n image,20w 50w \n', [
+      {url: 'image,20w', width: 50},
+      {url: 'image,100w', width: 100},
+    ]);
+    test(' \n image,2 2x\n , \n image,1', [
+      {url: 'image,1', dpr: 1},
+      {url: 'image,2', dpr: 2},
+    ]);
+    test(' \n image,2x 2x\n , \n image,1x', [
+      {url: 'image,1x', dpr: 1},
+      {url: 'image,2x', dpr: 2},
+    ]);
+    test(' \n image,2 , \n  image,1 2x\n', [
+      {url: 'image,2', dpr: 1},
+      {url: 'image,1', dpr: 2},
+    ]);
+    test(' \n image,1x , \n  image,2x 2x\n', [
+      {url: 'image,1x', dpr: 1},
+      {url: 'image,2x', dpr: 2},
+    ]);
+    test(' \n image,1 \n ', [{url: 'image,1', dpr: 1}]);
+    test(' \n image,1x \n ', [{url: 'image,1x', dpr: 1}]);
+  });
+
+  it('should accept no-whitestpace', () => {
+    test('image 100w,image 50w', [
+      {url: 'image', width: 50},
+      {url: 'image', width: 100},
+    ]);
+    test('image,1 100w,image,2 50w', [
+      {url: 'image,2', width: 50},
+      {url: 'image,1', width: 100},
+    ]);
+    test('image,1 2x,image,2', [
+      {url: 'image,2', dpr: 1},
+      {url: 'image,1', dpr: 2},
+    ]);
+    test('image,2 2x', [{url: 'image,2', dpr: 2}]);
+    test('image,1', [{url: 'image,1', dpr: 1}]);
+  });
+
+  it('should accept other special chars in URLs', () => {
+    test(' \n http://im-a+ge;1?&2#3 100w\n , \n image;2 50w \n', [
+      {url: 'image;2', width: 50},
+      {url: 'http://im-a+ge;1?&2#3', width: 100},
+    ]);
+  });
+
+  it('should accept false cognitives in URLs', () => {
+    test(' \n image,100w 100w\n , \n image,20x 50w \n', [
+      {url: 'image,20x', width: 50},
+      {url: 'image,100w', width: 100},
+    ]);
+    test(' \n image,1x 2x\n , \n image,2x', [
+      {url: 'image,2x', dpr: 1},
+      {url: 'image,1x', dpr: 2},
+    ]);
+    test(' \n image,1x \n ', [{url: 'image,1x', dpr: 1}]);
+    test(' \n image,1w \n ', [{url: 'image,1w', dpr: 1}]);
+  });
+
+  it('should not accept mixed sources', () => {
+    expect(() => {
+      parseSrcset(' \n image1 100w\n , \n image2 1.5x\n , image3 ');
+    }).toThrow(/Srcset must have width or dpr sources, but not both/);
+  });
+
+  it('should parse misc examples', () => {
+    test('image-1x.png 1x, image-2x.png 2x, image-3x.png 3x, image-4x.png 4x', [
+      {url: 'image-1x.png', dpr: 1},
+      {url: 'image-2x.png', dpr: 2},
+      {url: 'image-3x.png', dpr: 3},
+      {url: 'image-4x.png', dpr: 4},
+    ]);
+    test('image,one.png', [{url: 'image,one.png', dpr: 1}]);
+  });
+});
+
+describe('select', () => {
+  it('select by width', () => {
+    const srcset = parseSrcset('image-1000 1000w, image-500 500w, image-250 250w, image 50w');
+
+    // DPR = 1
+    expect(srcset.select(2000, 1)).toEqual('image-1000');
+    expect(srcset.select(1100, 1)).toEqual('image-1000');
+    expect(srcset.select(1000, 1)).toEqual('image-1000');
+    expect(srcset.select(900, 1)).toEqual('image-1000');
+    expect(srcset.select(800, 1)).toEqual('image-1000');
+    // select image-1000
+    expect(srcset.select(700, 1)).toEqual('image-1000');
+    expect(srcset.select(600, 1)).toEqual('image-500');
+    expect(srcset.select(500, 1)).toEqual('image-500');
+    expect(srcset.select(400, 1)).toEqual('image-500');
+    expect(srcset.select(300, 1)).toEqual('image-250');
+    expect(srcset.select(200, 1)).toEqual('image-250');
+    expect(srcset.select(100, 1)).toEqual('image-250');
+    expect(srcset.select(50, 1)).toEqual('image');
+    expect(srcset.select(1, 1)).toEqual('image');
+
+    // DPR = 2
+    expect(srcset.select(2000, 2)).toEqual('image-1000');
+    expect(srcset.select(1100, 2)).toEqual('image-1000');
+    expect(srcset.select(1000, 2)).toEqual('image-1000');
+    expect(srcset.select(900, 2)).toEqual('image-1000');
+    expect(srcset.select(800, 2)).toEqual('image-1000');
+    expect(srcset.select(700, 2)).toEqual('image-1000');
+    expect(srcset.select(600, 2)).toEqual('image-1000');
+    expect(srcset.select(500, 2)).toEqual('image-1000');
+    expect(srcset.select(400, 2)).toEqual('image-1000');
+    expect(srcset.select(300, 2)).toEqual('image-500');
+    expect(srcset.select(200, 2)).toEqual('image-500');
+    expect(srcset.select(100, 2)).toEqual('image-250');
+    expect(srcset.select(50, 2)).toEqual('image-250');
+    expect(srcset.select(1, 2)).toEqual('image');
+  });
+
+  it('select by width with preference toward higher width', () => {
+    const srcset = parseSrcset('image-1000 1000w, image-500 500w, image-250 250w, image 50w');
+
+    // For DPR=1 and 2.
+    // Bull's eye.
+    expect(srcset.select(500, 1)).toEqual('image-500');
+    expect(srcset.select(250, 2)).toEqual('image-500');
+
+    // Right in between: (1000 + 500)/2 = 750 -> preference for the higher
+    // value.
+    expect(srcset.select(750, 1)).toEqual('image-1000');
+    expect(srcset.select(375, 2)).toEqual('image-1000');
+
+    // Even higher: 850 -> higher value.
+    expect(srcset.select(850, 1)).toEqual('image-1000');
+    expect(srcset.select(425, 2)).toEqual('image-1000');
+
+    // Slightly lower: ~10% -> 740 -> still higher value.
+    expect(srcset.select(740, 1)).toEqual('image-1000');
+    expect(srcset.select(370, 2)).toEqual('image-1000');
+
+    // Lower than threshold but difference ratio (730/500 = 1.46) too high ->
+    // higher value
+    expect(srcset.select(730, 1)).toEqual('image-1000');
+    expect(srcset.select(365, 2)).toEqual('image-1000');
+
+    // Lower than threshold and difference ratio (600/500 = 1.2) is low enough
+    // -> lower value
+    expect(srcset.select(600, 1)).toEqual('image-500');
+    expect(srcset.select(300, 2)).toEqual('image-500');
+  });
+
+  it('select by dpr', () => {
+    const srcset = parseSrcset('image-3x 3x, image-2x 2x, image 1x');
+
+    expect(srcset.select(2000, 4)).toEqual('image-3x', 'dpr=4');
+    expect(srcset.select(2000, 3.5)).toEqual('image-3x', 'dpr=3.5');
+    expect(srcset.select(2000, 3)).toEqual('image-3x', 'dpr=3');
+    expect(srcset.select(2000, 2.7)).toEqual('image-3x', 'dpr=2.7');
+    expect(srcset.select(2000, 2.5)).toEqual('image-3x', 'dpr=2.5');
+    expect(srcset.select(2000, 2.3)).toEqual('image-2x', 'dpr=2.3');
+    expect(srcset.select(2000, 2)).toEqual('image-2x', 'dpr=2');
+    expect(srcset.select(2000, 1.7)).toEqual('image-2x', 'dpr=1.7');
+    expect(srcset.select(2000, 1.5)).toEqual('image-2x', 'dpr=1.5');
+    expect(srcset.select(2000, 1.3)).toEqual('image', 'dpr=1.3');
+    expect(srcset.select(2000, 1.2)).toEqual('image', 'dpr=1.2');
+    expect(srcset.select(2000, 1)).toEqual('image', 'dpr=1');
+  });
+});

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-video_with_missing_poster/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-video_with_missing_poster/expected_output.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <amp-video width="400" height="400">
+    <source src="foo.mp4">
+  </amp-video>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-video_with_missing_poster/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-video_with_missing_poster/input.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <amp-video width="400" height="400">
+    <source src="foo.mp4" />
+  </amp-video>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/config.json
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/config.json
@@ -1,0 +1,3 @@
+{
+  "experimentPreloadHeroImage": true
+}

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/disable_via_param/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/disable_via_param/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/foo.png">
+  </amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/disable_via_param/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/disable_via_param/input.html
@@ -1,0 +1,13 @@
+<!--
+{
+  "preloadHeroImage": false
+}
+-->
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/foo.png">
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimensions_from_parent_container/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimensions_from_parent_container/expected_output.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
+</head>
+<body>
+  <div width="500" height="500">
+    <amp-img layout="fill" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimensions_from_parent_container/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimensions_from_parent_container/input.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div width="500" height="500">
+    <amp-img layout="fill" src=https://example-com.cdn.ampproject.org/foo.png></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimesions_from_parent_container-_too_small/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimesions_from_parent_container-_too_small/expected_output.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div width="50" height="50">
+    <amp-img layout="fill" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimesions_from_parent_container-_too_small/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimesions_from_parent_container-_too_small/input.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div width="50" height="50">
+    <amp-img layout="fill" src=https://example-com.cdn.ampproject.org/foo.png></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
+</head>
+<body>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr">
+  </amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset/input.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr">
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset_duplicates/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset_duplicates/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
+</head>
+<body>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="foo 10w, bar 10w, baz 100w">
+  </amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset_duplicates/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/invalid_srcset_duplicates/input.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="foo 10w, bar 10w, baz 100w">
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimension_from_parent_because_layout_is_not_responsive_or_fill/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimension_from_parent_because_layout_is_not_responsive_or_fill/expected_output.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div>
+    <amp-img src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimension_from_parent_because_layout_is_not_responsive_or_fill/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimension_from_parent_because_layout_is_not_responsive_or_fill/input.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div>
+    <amp-img src=https://example-com.cdn.ampproject.org/foo.png></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimensions_in_parent_containers/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimensions_in_parent_containers/expected_output.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div>
+    <amp-img layout="fill" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimensions_in_parent_containers/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_dimensions_in_parent_containers/input.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <div>
+    <amp-img layout="fill" src=https://example-com.cdn.ampproject.org/foo.png></amp-img>
+  </div>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_display_layout/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_display_layout/expected_output.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+  <amp-img height="500" src="https://example-com.cdn.ampproject.org/foo.png" width="500" layout="nodisplay"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_display_layout/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/no_display_layout/input.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+  <amp-img height=500 src=https://example-com.cdn.ampproject.org/foo.png width=500 layout=nodisplay></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/preloads_hero_image/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/preloads_hero_image/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="preload" href="/foo.png" as="image" data-hero>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/foo.png"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/preloads_hero_image/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/preloads_hero_image/input.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/foo.png"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/same_as_above_with_nodisplay_layout_removed/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/same_as_above_with_nodisplay_layout_removed/expected_output.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
+</head>
+<body>
+  <amp-img height="500" src="https://example-com.cdn.ampproject.org/foo.png" width="500"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/same_as_above_with_nodisplay_layout_removed/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/same_as_above_with_nodisplay_layout_removed/input.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+  <amp-img height=500 src=https://example-com.cdn.ampproject.org/foo.png width=500></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_validity_empty_srcset/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_validity_empty_srcset/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
+</head>
+<body>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset>
+  </amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_validity_empty_srcset/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_validity_empty_srcset/input.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="">
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/video_posters/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/video_posters/expected_output.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
+</head>
+<body>
+  <amp-video poster="https://example-com.cdn.ampproject.org/foo.png" width="400" height="400">
+    <source src="foo.mp4">
+  </amp-video>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/video_posters/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/video_posters/input.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+  <amp-video poster="https://example-com.cdn.ampproject.org/foo.png" width="400" height="400">
+    <source src="foo.mp4" />
+  </amp-video>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a new transformer that uses a set of heuristics to detect an hero image on an AMP page and inject a preload directive to speed up rendering.