### PR TITLE
fix: add missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
       "requires": {
         "@ampproject/toolbox-cache-list": "^2.4.0-alpha.1",
         "@ampproject/toolbox-cache-url": "^2.3.0",
+        "@ampproject/toolbox-core": "^2.4.0-alpha.1",
         "@ampproject/toolbox-linter": "^2.4.0",
         "@ampproject/toolbox-optimizer": "^2.4.0",
         "@ampproject/toolbox-runtime-fetch": "^2.4.0-alpha.1",
@@ -267,6 +268,7 @@
         "@ampproject/toolbox-runtime-version": "^2.4.0-alpha.1",
         "@ampproject/toolbox-script-csp": "^2.3.0",
         "@ampproject/toolbox-validator-rules": "^2.3.0",
+        "cross-fetch": "3.0.4",
         "cssnano": "4.1.10",
         "dom-serializer": "1.0.1",
         "domhandler": "3.0.0",
@@ -340,22 +342,29 @@
           }
         },
         "postcss": {
-          "version": "7.0.26",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+          "version": "7.0.31",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.31.tgz",
+          "integrity": "sha512-a937VDHE1ftkjk+8/7nj/mrjtmkn69xxzJgRETXdAUU+IgOYPQNJF17haGWbeDxSyk++HA14UA98FurvPyBJOA==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
             "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ=="
         },
         "terser": {
           "version": "4.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@ampproject/toolbox-cache-list": "^2.4.0-alpha.1",
     "@ampproject/toolbox-cache-url": "^2.3.0",
+    "@ampproject/toolbox-core": "^2.4.0-alpha.1",
     "@ampproject/toolbox-linter": "^2.4.0",
     "@ampproject/toolbox-optimizer": "^2.4.0",
     "@ampproject/toolbox-runtime-fetch": "^2.4.0-alpha.1",

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -33,6 +33,7 @@
     "@ampproject/toolbox-runtime-version": "^2.4.0-alpha.1",
     "@ampproject/toolbox-script-csp": "^2.3.0",
     "@ampproject/toolbox-validator-rules": "^2.3.0",
+    "cross-fetch": "3.0.4",
     "cssnano": "4.1.10",
     "dom-serializer": "1.0.1",
     "domhandler": "3.0.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

optimizer and cli is missing a few dependencies which break Yarn PnP support in Next.js

Continuation of https://github.com/ampproject/amp-toolbox/pull/799

**How did you fix it?**

- Added `@ampproject/toolbox-core` to cli
- Added `cross-fetch` to optimizer