### PR TITLE
Improve preload handling with runtime self hosting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     "@ampproject/toolbox-cache-list": {
       "version": "file:packages/cache-list",
       "requires": {
-        "@ampproject/toolbox-core": "^2.5.1"
+        "@ampproject/toolbox-core": "^2.5.4"
       }
     },
     "@ampproject/toolbox-cache-url": {
@@ -81,14 +81,14 @@
     "@ampproject/toolbox-cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^2.5.1",
-        "@ampproject/toolbox-cache-url": "^2.3.0",
-        "@ampproject/toolbox-core": "^2.5.1",
-        "@ampproject/toolbox-linter": "^2.5.2",
-        "@ampproject/toolbox-optimizer": "^2.5.3",
-        "@ampproject/toolbox-runtime-fetch": "^2.5.1",
-        "@ampproject/toolbox-runtime-version": "^2.5.1",
-        "@ampproject/toolbox-update-cache": "^2.5.1",
+        "@ampproject/toolbox-cache-list": "^2.5.4",
+        "@ampproject/toolbox-cache-url": "^2.5.4",
+        "@ampproject/toolbox-core": "^2.5.4",
+        "@ampproject/toolbox-linter": "^2.5.4",
+        "@ampproject/toolbox-optimizer": "^2.5.5",
+        "@ampproject/toolbox-runtime-fetch": "^2.5.4",
+        "@ampproject/toolbox-runtime-version": "^2.5.4",
+        "@ampproject/toolbox-update-cache": "^2.5.4",
         "minimist": "1.2.5",
         "minimist-options": "4.1.0",
         "node-fetch": "2.6.0"
@@ -243,16 +243,16 @@
     "@ampproject/toolbox-cors": {
       "version": "file:packages/cors",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^2.5.1",
-        "@ampproject/toolbox-cache-url": "^2.3.0",
-        "@ampproject/toolbox-core": "^2.5.1"
+        "@ampproject/toolbox-cache-list": "^2.5.4",
+        "@ampproject/toolbox-cache-url": "^2.5.4",
+        "@ampproject/toolbox-core": "^2.5.4"
       }
     },
     "@ampproject/toolbox-linter": {
       "version": "file:packages/linter",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^2.5.1",
-        "@ampproject/toolbox-cache-url": "^2.3.0",
+        "@ampproject/toolbox-cache-list": "^2.5.4",
+        "@ampproject/toolbox-cache-url": "^2.5.4",
         "amphtml-validator": "1.0.31",
         "chalk": "4.1.0",
         "cheerio": "1.0.0-rc.3",
@@ -392,10 +392,10 @@
     "@ampproject/toolbox-optimizer": {
       "version": "file:packages/optimizer",
       "requires": {
-        "@ampproject/toolbox-core": "^2.5.1",
-        "@ampproject/toolbox-runtime-version": "^2.5.1",
-        "@ampproject/toolbox-script-csp": "^2.3.0",
-        "@ampproject/toolbox-validator-rules": "^2.3.0",
+        "@ampproject/toolbox-core": "^2.5.4",
+        "@ampproject/toolbox-runtime-version": "^2.5.4",
+        "@ampproject/toolbox-script-csp": "^2.5.4",
+        "@ampproject/toolbox-validator-rules": "^2.5.4",
         "abort-controller": "3.0.0",
         "cross-fetch": "3.0.5",
         "cssnano": "4.1.10",
@@ -505,18 +505,23 @@
           }
         },
         "terser": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
-          "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw=="
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
         }
       }
     },
     "@ampproject/toolbox-optimizer-express": {
       "version": "file:packages/optimizer-express",
       "requires": {
-        "@ampproject/toolbox-core": "^2.5.1",
-        "@ampproject/toolbox-optimizer": "^2.5.3",
-        "@ampproject/toolbox-runtime-version": "^2.5.1",
+        "@ampproject/toolbox-core": "^2.5.4",
+        "@ampproject/toolbox-optimizer": "^2.5.5",
+        "@ampproject/toolbox-runtime-version": "^2.5.4",
         "mime-types": "2.1.27",
         "whatwg-url": "8.1.0"
       },
@@ -674,9 +679,9 @@
     "@ampproject/toolbox-runtime-fetch": {
       "version": "file:packages/runtime-fetch",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^2.5.1",
-        "@ampproject/toolbox-core": "^2.5.1",
-        "@ampproject/toolbox-runtime-version": "^2.5.1",
+        "@ampproject/toolbox-cache-list": "^2.5.4",
+        "@ampproject/toolbox-core": "^2.5.4",
+        "@ampproject/toolbox-runtime-version": "^2.5.4",
         "at-least-node": "1.0.0",
         "cross-fetch": "3.0.5",
         "fs-extra": "9.0.1"
@@ -763,7 +768,7 @@
     "@ampproject/toolbox-runtime-version": {
       "version": "file:packages/runtime-version",
       "requires": {
-        "@ampproject/toolbox-core": "^2.5.1"
+        "@ampproject/toolbox-core": "^2.5.4"
       }
     },
     "@ampproject/toolbox-script-csp": {
@@ -772,8 +777,8 @@
     "@ampproject/toolbox-update-cache": {
       "version": "file:packages/update-cache",
       "requires": {
-        "@ampproject/toolbox-cache-list": "^2.5.1",
-        "@ampproject/toolbox-cache-url": "^2.3.0",
+        "@ampproject/toolbox-cache-list": "^2.5.4",
+        "@ampproject/toolbox-cache-url": "^2.5.4",
         "jsrsasign": "8.0.18"
       },
       "dependencies": {
@@ -4668,8 +4673,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/debug": {
       "version": "4.1.5",
@@ -7738,7 +7742,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -9201,7 +9204,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
       "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -9641,8 +9643,7 @@
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-      "dev": true
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
     },
     "growly": {
       "version": "1.3.0",
@@ -9979,8 +9980,7 @@
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "humanize-ms": {
       "version": "1.2.1",
@@ -10594,8 +10594,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-subset": {
       "version": "0.1.1",
@@ -10667,8 +10666,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -13882,8 +13880,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "merge2": {
       "version": "1.4.1",
@@ -14024,8 +14021,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "min-document": {
       "version": "2.19.0",
@@ -15013,7 +15009,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "requires": {
         "path-key": "^3.0.0"
       },
@@ -15021,8 +15016,7 @@
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         }
       }
     },
@@ -15292,7 +15286,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -15301,7 +15294,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -16737,7 +16729,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -17874,8 +17865,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -18790,8 +18780,7 @@
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-indent": {
       "version": "3.0.0",
@@ -19190,16 +19179,6 @@
       "requires": {
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
-      }
-    },
-    "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
       }
     },
     "test-exclude": {
@@ -20236,8 +20215,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_esm/expected_output.html
@@ -3,12 +3,12 @@
 <head>
   <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
   <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_geoapi/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_geoapi/expected_output.html
@@ -4,12 +4,12 @@
   <meta name="amp-geo-api" content="/geo">
   <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
   <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_lts/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_lts/expected_output.html
@@ -3,12 +3,12 @@
 <head>
   <script async nomodule src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/lts/v0.mjs" rel="preload">
   <script async nomodule src="https://cdn.ampproject.org/lts/v0.js"></script>
   <script async src="https://cdn.ampproject.org/lts/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/lts/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/lts/v0.mjs" rel="preload">
   <link rel="preload" href="https://cdn.ampproject.org/lts/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_preloads/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_preloads/expected_output.html
@@ -3,12 +3,12 @@
 <head>
   <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
   <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="preload">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_runtime_version/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/adds_runtime_version/expected_output.html
@@ -3,12 +3,12 @@
 <head>
   <script async nomodule src="https://cdn.ampproject.org/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/rtv/001515617716922/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/rtv/001515617716922/v0.mjs" rel="preload">
   <script async nomodule src="https://cdn.ampproject.org/rtv/001515617716922/v0.js"></script>
   <script async src="https://cdn.ampproject.org/rtv/001515617716922/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/rtv/001515617716922/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/rtv/001515617716922/v0.mjs" rel="preload">
   <link rel="preload" href="https://cdn.ampproject.org/rtv/001515617716922/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
@@ -4,12 +4,12 @@
   <meta name="runtime-host" content="/amp">
   <script async nomodule src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="/amp/rtv/001515617716922/v0.mjs" rel="preload">
   <script async nomodule src="/amp/rtv/001515617716922/v0.js"></script>
   <script async src="/amp/rtv/001515617716922/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="/amp/rtv/001515617716922/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="/amp/rtv/001515617716922/v0.mjs" rel="preload">
   <link rel="preload" href="/amp/rtv/001515617716922/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
@@ -4,12 +4,13 @@
   <meta name="runtime-host" content="/amp">
   <script async nomodule src="/amp/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="/amp/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <link as="script" crossorigin="anonymous" href="/amp/v0.mjs" rel="preload">
   <script async nomodule src="/amp/v0.js"></script>
   <script async src="/amp/v0.mjs" type="module" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="/amp/v0.css">
+
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="/amp/v0.mjs" rel="preload">
   <link rel="preload" href="/amp/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/input.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/input.html
@@ -9,6 +9,7 @@
   <script async custom-element=amp-experiment src=https://cdn.ampproject.org/v0/amp-experiment-0.1.js></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel=stylesheet href=https://cdn.ampproject.org/v0.css>
+  <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
   <link href=https://example.com/favicon.ico rel=icon>
 </head>


### PR DESCRIPTION
* remove v0.js preloads if esm mode is enabled (the esm modules should
be preloaded instead)
* rename existing v0.js preloads