### PR TITLE
Only inject runtime-host meta tag if host is given

### DIFF
--- a/packages/optimizer/lib/transformers/RewriteAmpUrls.js
+++ b/packages/optimizer/lib/transformers/RewriteAmpUrls.js
@@ -57,6 +57,7 @@ const {calculateHost} = require('../RuntimeHostHelper');
 class RewriteAmpUrls {
   constructor(config) {
     this.esmModulesEnabled = config.experimentEsm;
+    this.log = config.log;
   }
   transform(root, params) {
     const html = firstChildByTag(root, 'html');
@@ -109,13 +110,12 @@ class RewriteAmpUrls {
 
     // runtime-host and amp-geo-api meta tags should appear before the first script
     if (!this._usesAmpCacheUrl(host) && !params.lts) {
-      let versionlessHost;
-      if (this.isAbsoluteUrl_(params.ampUrlPrefix)) {
-        versionlessHost = calculateHost({ampUrlPrefix: params.ampUrlPrefix});
-      } else {
-        versionlessHost = '.';
+      try {
+        const url = new URL(host);
+        this._addMeta(head, 'runtime-host', url.origin);
+      } catch (e) {
+        this.log.warn('ampUrlPrefix must be an absolute URL');
       }
-      this._addMeta(head, 'runtime-host', versionlessHost);
     }
     if (params.geoApiUrl && !params.lts) {
       this._addMeta(head, 'amp-geo-api', params.geoApiUrl);

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"><style amp-runtime i-amphtml-version="123456789000000">/* example.com v0.css */</style>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <link rel="preload" href="https://example.com/amp/rtv/123456789000000/v0.js" as="script">
-  <meta name="runtime-host" content="https://example.com/amp">
+  <meta name="runtime-host" content="https://example.com">
   <meta name="amp-geo-api" content="/geo">
   <script async src="https://example.com/amp/rtv/123456789000000/v0.js"></script>
   <script async custom-element="amp-experiment" src="https://example.com/amp/rtv/123456789000000/v0/amp-experiment-0.1.js"></script>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_host_and_adds_version/expected_output.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <meta name="runtime-host" content=".">
   <script async nomodule src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="/amp/rtv/001515617716922/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
   <script async nomodule src="/amp/rtv/001515617716922/v0.js"></script>

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/rewrites_hosts/expected_output.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <meta name="runtime-host" content=".">
   <script async nomodule src="/amp/v0/amp-experiment-0.1.js"></script>
   <script async custom-element="amp-experiment" src="/amp/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
   <script async nomodule src="/amp/v0.js"></script>


### PR DESCRIPTION
* Only include host in runtime-host meta tag
* Print warning if ampUrlPrefix is not absolute
* Don't inject runtime-host meta tag if ampUrlPrefix is not absolute.
This will fallback to cdn.ampproject.org.