### PR TITLE
Linter rule for Google Font preconnect

### DIFF
--- a/packages/linter/src/index.ts
+++ b/packages/linter/src/index.ts
@@ -28,6 +28,7 @@ import { BlockingExtensionsPreloaded } from "./rules/BlockingExtensionsPreloaded
 import { FontsArePreloaded } from "./rules/FontsArePreloaded";
 import { HeroImageIsDefined } from "./rules/HeroImageIsDefined";
 import { FastGoogleFontsDisplay } from "./rules/FastGoogleFontsDisplay";
+import { GoogleFontPreconnect } from "./rules/GoogleFontPreconnect";
 import { RuleConstructor } from "./rule";
 import { isArray } from "util";
 
@@ -135,6 +136,7 @@ function testsForMode(type: LintMode) {
       BlockingExtensionsPreloaded,
       FontsArePreloaded,
       FastGoogleFontsDisplay,
+      GoogleFontPreconnect,
       IsTransformedAmp,
       ModuleRuntimeUsed,
       HeroImageIsDefined,

--- a/packages/linter/src/rules/FastGoogleFontsDisplay.ts
+++ b/packages/linter/src/rules/FastGoogleFontsDisplay.ts
@@ -4,9 +4,8 @@ import { Rule } from "../rule";
 const GOOGLE_FONT_URL_PATTERN = /https?:\/\/fonts.googleapis.com\/css\?(?!(?:[\s\S]+&)?display=(?:swap|fallback|optional)(?:&|$))/i;
 
 /**
- * This test will return an info when font-face definitions with a url
- * but no fonts are preloaded.
- * Font definitions with url but an additional font-display setting are ignored.
+ * Checks if Google Font stylesheets are loaded with the display parameter
+ * value of 'swap', 'fallback', or 'optional'
  */
 export class FastGoogleFontsDisplay extends Rule {
   run({ $ }: Context) {

--- a/packages/linter/src/rules/GoogleFontPreconnect.ts
+++ b/packages/linter/src/rules/GoogleFontPreconnect.ts
@@ -1,0 +1,37 @@
+import { Context } from "../index";
+import { Rule } from "../rule";
+
+/**
+ * This rule tests if the page contains a dns-prefetch and preconnect for
+ * fonts.gstatic.com when Google Fonts are used.
+ */
+export class GoogleFontPreconnect extends Rule {
+  run({ $ }: Context) {
+    const fonts = $(
+      "link[rel='stylesheet'][href^='https://fonts.googleapis.com/css']"
+    );
+    if (!fonts.length) {
+      return this.pass();
+    }
+    const preconnect = $(
+      "link[href*='//fonts.gstatic.com'][rel~='preconnect'][crossorigin]"
+    );
+    const dnsPrefetch = $(
+      "link[href*='//fonts.gstatic.com'][rel~='dns-prefetch']"
+    );
+    if (!preconnect.length || !dnsPrefetch.length) {
+      return this.warn(
+        `Preconnect Google Fonts using <link href=https://fonts.gstatic.com rel="dns-prefetch preconnect" crossorigin>`
+      );
+    }
+    return this.pass();
+  }
+  meta() {
+    return {
+      url:
+        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading",
+      title: "Preconnecting Google Fonts",
+      info: "",
+    };
+  }
+}

--- a/packages/linter/tests/local.test.ts
+++ b/packages/linter/tests/local.test.ts
@@ -22,6 +22,7 @@ import { BlockingExtensionsPreloaded } from "../src/rules/BlockingExtensionsPrel
 import { FontsArePreloaded } from "../src/rules/FontsArePreloaded";
 import { HeroImageIsDefined } from "../src/rules/HeroImageIsDefined";
 import { FastGoogleFontsDisplay } from "../src/rules/FastGoogleFontsDisplay";
+import { GoogleFontPreconnect } from "../src/rules/GoogleFontPreconnect";
 
 describe(AmpImgAmpPixelPreferred.name, () => {
   it(`${AmpImgAmpPixelPreferred.name} - <amp-img height="1" width="1">`, async () => {
@@ -145,6 +146,33 @@ describe(FontsArePreloaded.name, () => {
       runLocalTest(
         FontsArePreloaded,
         `${__dirname}/local/FontsArePreloaded-3/source.html`
+      )
+    );
+  });
+});
+
+describe(GoogleFontPreconnect.name, () => {
+  it(`${GoogleFontPreconnect.name} - dns-prefetch preconnect exists`, async () => {
+    return assertPass(
+      runLocalTest(
+        GoogleFontPreconnect,
+        `${__dirname}/local/GoogleFontPreconnect-1/source.html`
+      )
+    );
+  });
+  it(`${GoogleFontPreconnect.name} - preconnect missing`, async () => {
+    return assertWarn(
+      runLocalTest(
+        GoogleFontPreconnect,
+        `${__dirname}/local/GoogleFontPreconnect-2/source.html`
+      )
+    );
+  });
+  it(`${GoogleFontPreconnect.name} - dns-prefetch missing`, async () => {
+    return assertWarn(
+      runLocalTest(
+        GoogleFontPreconnect,
+        `${__dirname}/local/GoogleFontPreconnect-3/source.html`
       )
     );
   });

--- a/packages/linter/tests/local/GoogleFontPreconnect-1/source.html
+++ b/packages/linter/tests/local/GoogleFontPreconnect-1/source.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>Hello, AMPs</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "headline": "Open-source framework for publishing content",
+        "datePublished": "2015-10-07T12:02:41Z",
+        "image": [
+          "logo.jpg"
+        ]
+      }
+    </script>
+    <link rel="preconnect dns-prefetch" href="//fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Font1&display=swap">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+    </style>
+  </head>
+  <body>
+    <h1>Hello, AMP!</h1>
+  </body>
+</html>

--- a/packages/linter/tests/local/GoogleFontPreconnect-2/source.html
+++ b/packages/linter/tests/local/GoogleFontPreconnect-2/source.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>Hello, AMPs</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "headline": "Open-source framework for publishing content",
+        "datePublished": "2015-10-07T12:02:41Z",
+        "image": [
+          "logo.jpg"
+        ]
+      }
+    </script>
+    <link rel="dns-prefetch" href="//fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Font1&display=swap">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+    </style>
+  </head>
+  <body>
+    <h1>Hello, AMP!</h1>
+  </body>
+</html>

--- a/packages/linter/tests/local/GoogleFontPreconnect-3/source.html
+++ b/packages/linter/tests/local/GoogleFontPreconnect-3/source.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>Hello, AMPs</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "headline": "Open-source framework for publishing content",
+        "datePublished": "2015-10-07T12:02:41Z",
+        "image": [
+          "logo.jpg"
+        ]
+      }
+    </script>
+    <link rel="preconnect" href="//fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Font1&display=swap">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+    </style>
+  </head>
+  <body>
+    <h1>Hello, AMP!</h1>
+  </body>
+</html>


### PR DESCRIPTION
This new check will return a warning when Google Fonts are used, but there is no "preconnect" and no "dns-prefetch" for "fonts.gstatic.com" (It is fine if "preconnect" and "dns-prefetch" are in the same link tag or are specified in separated link tags) 

There are examples that only have "preconnect" for "fonts.gstatic.com" or have "preconnect" for "fonts.gstatic.com" but "dns-prefetch" for "fonts.googleapis.com". Those would generate a warning here.