### PR TITLE
Allow users to specify version numbers for auto imported extensions

### DIFF
--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -81,6 +81,7 @@ Available options are:
 
 - [autoAddMandatoryTags](#autoaddmandatorytags)
 - [autoExtensionImport](#autoextensionimport)
+- [extensionVersions](#extensionversions)
 - [fetch](#fetch)
 - [format](#format)
 - [imageBasePath](#imagebasePath)
@@ -107,7 +108,26 @@ Automatically import any missing AMP Extensions (e.g. amp-carousel).
 - name: `autoExtensionImport`
 - valid options: `[true|false]`
 - default: `true`
-- used by: [AutoExtensionImport](lib/transformers/AddMandatoryTags.js)
+- used by: [AutoExtensionImport](lib/transformers/AutoExtensionImporter.js)
+
+#### `extensionVersions`
+
+Specify version numbers to use for automatically imported Extensions. If not defined, default to latest.
+
+Example:
+
+```js
+const ampOptimizer = AmpOptimizer.create({
+  extensionVersions: {
+    "amp-twitter": "0.1"
+  }
+});
+```
+
+- name: `extensionVersions`
+- valid options: `OBJECT`
+- default: `{}`
+- used by: [AutoExtensionImport](lib/transformers/AutoExtensionImporter.js)
 
 #### `format`
 
@@ -116,7 +136,7 @@ Specifies the AMP format of the input file. Defaults to `AMP`.
 - name: `format`
 - valid options: `[AMP|AMP4EMAIL|AMP4ADS]`
 - default: `AMP`
-- used by: [AutoExtensionImport](lib/transformers/AddMandatoryTags.js), [AddMandatoryTags](lib/transformers/AddMandatoryTags.js)
+- used by: [AutoExtensionImport](lib/transformers/AutoExtensionImporter.js), [AddMandatoryTags](lib/transformers/AddMandatoryTags.js)
 
 #### `experimentEsm`
 

--- a/packages/optimizer/lib/transformers/AutoExtensionImporter.js
+++ b/packages/optimizer/lib/transformers/AutoExtensionImporter.js
@@ -60,6 +60,7 @@ class AutoExtensionImporter {
     this.format = config.format || DEFAULT_FORMAT;
     this.log_ = config.log.tag('AutoExtensionImporter');
     this.experimentBindAttributeEnabled = config.experimentBindAttribute === true;
+    this.extensionVersions = config.extensionVersions || {};
   }
 
   /**
@@ -180,7 +181,11 @@ class AutoExtensionImporter {
       const extension = this.extensionSpec_.extensionsMap.get(extensionName.trim());
       this.log_.debug('auto importing', extensionName);
       // Use the latest version by default
-      const version = extension.version[extension.version.length - 1];
+      let version = extension.version[extension.version.length - 1];
+      // Let user override default
+      if (this.extensionVersions[extensionName]) {
+        version = this.extensionVersions[extensionName];
+      }
       const extensionImportAttribs = {
         async: '',
         src: `${host}/v0/${extensionName}-${version}.js`,

--- a/packages/optimizer/spec/transformers/valid/AutoExtensionImporter/allow-specific-version/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/AutoExtensionImporter/allow-specific-version/expected_output.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>My AMP Page</title>
+  <link rel="canonical" href="self.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <script async src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js" custom-element="amp-sticky-ad"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- this should import a specific version, not latest -->
+  <amp-sticky-ad layout="nodisplay"></amp-sticky-ad>
+</body>
+
+</html>

--- a/packages/optimizer/spec/transformers/valid/AutoExtensionImporter/allow-specific-version/input.html
+++ b/packages/optimizer/spec/transformers/valid/AutoExtensionImporter/allow-specific-version/input.html
@@ -1,0 +1,17 @@
+
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>My AMP Page</title>
+  <link rel="canonical" href="self.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+  <body>
+    <!-- this should import a specific version, not latest -->
+    <amp-sticky-ad layout="nodisplay"></amp-sticky-ad>
+  </body>
+
+</html>

--- a/packages/optimizer/spec/transformers/valid/AutoExtensionImporter/config.json
+++ b/packages/optimizer/spec/transformers/valid/AutoExtensionImporter/config.json
@@ -1,3 +1,6 @@
 {
-  "experimentBindAttribute": true
+  "experimentBindAttribute": true,
+  "extensionVersions": {
+    "amp-sticky-ad": "0.1"
+  }
 }


### PR DESCRIPTION
AutoExtensionImport adds the latest versions of extensions by default. Some projects/teams want more control so they can pin to a specific tested version and not worry about unexpected changes as new versions come out, or so they can manually run their tests before upgrading. Similar to the problem that yarn and npm use lockfiles to fix.

This PR allows a new config parameter to be passed in which describes the version number to be used for each extension.