### PR TITLE
Use node instead of root for checking templates in PreloadHeroImages

### DIFF
--- a/packages/optimizer/lib/transformers/PreloadHeroImage.js
+++ b/packages/optimizer/lib/transformers/PreloadHeroImage.js
@@ -137,7 +137,7 @@ class PreloadHeroImage {
       if (!heroImageCandidate && heroImages.length === 0) {
         heroImageCandidate = this.isCandidateHeroImage(node);
       }
-      if (amphtml.isTemplate(root)) {
+      if (amphtml.isTemplate(node)) {
         // Ignore images inside templates
         node = skipNodeAndChildren(node);
       } else {


### PR DESCRIPTION
In the `PreloadHeroImages` transformer's `findHeroImages()` method, the template check is always executed against the root `<body>` node, instead of the node currently being processed.

This PR swicthes the check from `root` to `node`.