### PR TITLE
Remove unneeded width & height checks

### DIFF
--- a/packages/optimizer/lib/transformers/PreloadHeroImage.js
+++ b/packages/optimizer/lib/transformers/PreloadHeroImage.js
@@ -277,7 +277,7 @@ class PreloadHeroImage {
     if (layout === 'intrinsic' || layout === 'responsive') {
       return false;
     }
-    return (width > 0 && width < TINY_IMG_THRESHOLD) || (height > 0 && height < TINY_IMG_THRESHOLD);
+    return width < TINY_IMG_THRESHOLD || height < TINY_IMG_THRESHOLD;
   }
 
   nodeDimensionsFromParent(node) {


### PR DESCRIPTION
The `isTinyNode()` method first ensures that all negative or zero values of either `width` or `height` are eliminated.

Then, after a check for responsiveness, it checks the `width` and `height` again for being a positive value. At his point, this is guaranteed to be true already by the first check, and thus only adds unneeded processing overhead.

This PR removes these unneeded checks, assuming that the initial check is correct.