### PR TITLE
Add missing closing tags to <amp-img> elements

### DIFF
--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_cannot_be_preloaded/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_cannot_be_preloaded/expected_output.html
@@ -2,9 +2,7 @@
 <head></head>
 <body>
   <!-- srcset is not supported by all browsers -->
-  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr" i-amphtml-ssr data-hero>
-	  <img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr">
-  </amp-img>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr"></amp-img>
   <!-- not preloaded as it's not a hero image -->
   <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
 </body>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_cannot_be_preloaded/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_cannot_be_preloaded/expected_output.html
@@ -3,9 +3,9 @@
 <body>
   <!-- srcset is not supported by all browsers -->
   <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr" i-amphtml-ssr data-hero>
-    <!-- not preloaded as it's not a hero image -->
-    <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png">
-    </amp-img><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr">
+	  <img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr">
   </amp-img>
+  <!-- not preloaded as it's not a hero image -->
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_cannot_be_preloaded/input.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_cannot_be_preloaded/input.html
@@ -2,8 +2,8 @@
 <head></head>
 <body>
   <!-- srcset is not supported by all browsers -->
-  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr">
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr"></amp-img>
   <!-- not preloaded as it's not a hero image -->
-  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png">
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
 </body>
 </html>


### PR DESCRIPTION
The `input.html` file for the `PreloadHeroImage/srcset_cannot_be_preloaded` spec test is missing the closing tags for its `<amp-img>` elements. This causes the DOM to get corrupted when imported and the `<amp-img>` elements to be inadvertently nested.

Fixes #917 