### PR TITLE
Bump node-fetch from 2.6.0 to 2.6.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "@ampproject/toolbox-update-cache": "^2.7.0-alpha.1",
     "minimist": "1.2.5",
     "minimist-options": "4.1.0",
-    "node-fetch": "2.6.0"
+    "node-fetch": "^2.6.1"
   },
   "gitHead": "da4cca026111b917cd3901b4666a5997ef45a606"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/ampproject/amp-toolbox/tree/main/packages/core",
   "dependencies": {
-    "cross-fetch": "3.0.5",
+    "cross-fetch": "^3.0.6",
     "lru-cache": "6.0.0"
   },
   "gitHead": "7a674fec36dd663876907c0c9ebd332ad3fe7967"

--- a/packages/lighthouse-plugin-amp/package.json
+++ b/packages/lighthouse-plugin-amp/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/ampproject/amp-toolbox/tree/main/packages/lighthouse-plugin-amp",
   "dependencies": {
     "amphtml-validator": "1.0.33",
-    "node-fetch": "2.6.0"
+    "node-fetch": "^2.6.1"
   },
   "version": "2.7.0-alpha.1",
   "main": "./plugin.js",

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -20,7 +20,7 @@
     "commander": "6.0.0",
     "debug": "4.1.1",
     "execa": "4.0.3",
-    "node-fetch": "2.6.0",
+    "node-fetch": "^2.6.1",
     "probe-image-size": "5.0.0",
     "throat": "5.0.0"
   },

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -34,7 +34,7 @@
     "@ampproject/toolbox-script-csp": "^2.5.4",
     "@ampproject/toolbox-validator-rules": "^2.5.4",
     "abort-controller": "3.0.0",
-    "cross-fetch": "3.0.5",
+    "cross-fetch": "^3.0.6",
     "cssnano-simple": "1.2.0",
     "dom-serializer": "1.0.1",
     "domhandler": "3.0.0",

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -42,7 +42,7 @@
     "htmlparser2": "4.1.0",
     "https-proxy-agent": "5.0.0",
     "lru-cache": "6.0.0",
-    "node-fetch": "2.6.0",
+    "node-fetch": "2.6.1",
     "normalize-html-whitespace": "1.0.0",
     "postcss": "7.0.32",
     "postcss-safe-parser": "4.0.2",

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -42,7 +42,7 @@
     "htmlparser2": "4.1.0",
     "https-proxy-agent": "5.0.0",
     "lru-cache": "6.0.0",
-    "node-fetch": "2.6.1",
+    "node-fetch": "^2.6.1",
     "normalize-html-whitespace": "1.0.0",
     "postcss": "7.0.32",
     "postcss-safe-parser": "4.0.2",

--- a/packages/runtime-fetch/package.json
+++ b/packages/runtime-fetch/package.json
@@ -24,7 +24,7 @@
     "@ampproject/toolbox-core": "^2.6.0",
     "@ampproject/toolbox-runtime-version": "^2.7.0-alpha.1",
     "at-least-node": "1.0.0",
-    "cross-fetch": "3.0.5",
+    "cross-fetch": "^3.0.6",
     "fs-extra": "9.0.1"
   },
   "bugs": {

--- a/packages/validator-rules/package.json
+++ b/packages/validator-rules/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/ampproject/amp-toolbox/issues"
   },
   "dependencies": {
-    "cross-fetch": "3.0.5"
+    "cross-fetch": "^3.0.6"
   },
   "homepage": "https://github.com/ampproject/amp-toolbox/tree/main/packages/validator-rules",
   "directories": {


### PR DESCRIPTION
While a low severity issue, node-fetch 2.6.0 has vulnerabilities. It is a good idea to bump node-fetch used from 2.6.0 to 2.6.1.

https://github.com/node-fetch/node-fetch/blob/master/docs/CHANGELOG.md#v261

Thats about it!