### PR TITLE
Remove unneeded extra semicolon

### DIFF
--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -118,7 +118,7 @@ function maybeAddSizerInto(node, layout, width, height) {
 function createResponsiveSizer(width, height) {
   const padding = (height.numeral / width.numeral) * 100;
   const sizer = createElement('i-amphtml-sizer', {
-    style: `display:block;padding-top:${padding.toFixed(4)}%;`,
+    style: `display:block;padding-top:${padding.toFixed(4)}%`,
   });
   return sizer;
 }


### PR DESCRIPTION
There's a trailing semi-colon being added to the inline style of the `i-amphtml-sizer`. This just adds wasted bytes to the HTML and should be removed.