### PR TITLE
Avoid trailing zeros and semicolons in sizer's padding

### DIFF
--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -118,7 +118,7 @@ function maybeAddSizerInto(node, layout, width, height) {
 function createResponsiveSizer(width, height) {
   const padding = (height.numeral / width.numeral) * 100;
   const sizer = createElement('i-amphtml-sizer', {
-    style: `display:block;padding-top:${padding.toFixed(4).replace(/\.?0*$/, '')}%`,
+    style: `display:block;padding-top:${parseFloat(padding.toFixed(4))}%`,
   });
   return sizer;
 }

--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -118,7 +118,7 @@ function maybeAddSizerInto(node, layout, width, height) {
 function createResponsiveSizer(width, height) {
   const padding = (height.numeral / width.numeral) * 100;
   const sizer = createElement('i-amphtml-sizer', {
-    style: `display:block;padding-top:${padding.toFixed(4)}%;`,
+    style: `display:block;padding-top:${padding.toFixed(4).replace(/\.?0*$/, '')}%`,
   });
   return sizer;
 }

--- a/packages/optimizer/spec/end-to-end/body-only/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/body-only/expected_output.default.html
@@ -12,7 +12,7 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>
   </amp-video>
 </body>
 </html>

--- a/packages/optimizer/spec/end-to-end/body-only/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/body-only/expected_output.lts.html
@@ -12,7 +12,7 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>
   </amp-video>
 </body>
 </html>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.default.html
@@ -14,10 +14,10 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%;"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>
     <div fallback>
       <p>Your browser doesn't support HTML5 video.</p>
     </div>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.lts.html
@@ -14,10 +14,10 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%;"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>
     <div fallback>
       <p>Your browser doesn't support HTML5 video.</p>
     </div>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
@@ -17,10 +17,10 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%;"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>
     <div fallback>
       <p>Your browser doesn't support HTML5 video.</p>
     </div>

--- a/packages/optimizer/spec/end-to-end/story/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/story/expected_output.default.html
@@ -28,7 +28,7 @@
         <h1>Hello World</h1>
         <p>This is the cover page of this story.</p>
         <amp-img data-hero src="https://amp.dev/static/samples/img/story_dog2.jpg" width="300" height="300" layout="responsive" alt class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-          <i-amphtml-sizer style="display:block;padding-top:100.0000%;"></i-amphtml-sizer>
+          <i-amphtml-sizer style="display:block;padding-top:100%"></i-amphtml-sizer>
         </amp-img>
       </amp-story-grid-layer>
     </amp-story-page>

--- a/packages/optimizer/spec/end-to-end/story/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/story/expected_output.lts.html
@@ -28,7 +28,7 @@
         <h1>Hello World</h1>
         <p>This is the cover page of this story.</p>
         <amp-img data-hero src="https://amp.dev/static/samples/img/story_dog2.jpg" width="300" height="300" layout="responsive" alt class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-          <i-amphtml-sizer style="display:block;padding-top:100.0000%;"></i-amphtml-sizer>
+          <i-amphtml-sizer style="display:block;padding-top:100%"></i-amphtml-sizer>
         </amp-img>
       </amp-story-grid-layer>
     </amp-story-page>

--- a/packages/optimizer/spec/end-to-end/story/expected_output.paired.html
+++ b/packages/optimizer/spec/end-to-end/story/expected_output.paired.html
@@ -29,7 +29,7 @@
         <h1>Hello World</h1>
         <p>This is the cover page of this story.</p>
         <amp-img data-hero src="https://amp.dev/static/samples/img/story_dog2.jpg" width="300" height="300" layout="responsive" alt class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-          <i-amphtml-sizer style="display:block;padding-top:100.0000%;"></i-amphtml-sizer>
+          <i-amphtml-sizer style="display:block;padding-top:100%"></i-amphtml-sizer>
         </amp-img>
       </amp-story-grid-layer>
     </amp-story-page>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/converts_heights_attribute_to_css/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/converts_heights_attribute_to_css/expected_output.html
@@ -9,7 +9,7 @@
 <body>
   <!-- converts heights to css -->
   <amp-img height="256" layout="responsive" src="https://acme.org/image1.png" width="320" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive" id="i-amp-0">
-    <i-amphtml-sizer style="display:block;padding-top:80.0000%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:80%"></i-amphtml-sizer>
   </amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/converts_sizes_attribute_to_css/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/converts_sizes_attribute_to_css/expected_output.html
@@ -10,11 +10,11 @@
 <body>
   <!-- requires srcset attribute -->
   <amp-img height="300" layout="responsive" src="https://acme.org/image1.png" width="400" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:75.0000%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:75%"></i-amphtml-sizer>
   </amp-img>
   <!-- sizes -->
   <amp-img height="300" layout="responsive" srcset="img-480w.jpg 480w,img-800w.jpg 800w" src="https://acme.org/image1.png" width="400" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive" id="i-amp-0">
-    <i-amphtml-sizer style="display:block;padding-top:75.0000%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:75%"></i-amphtml-sizer>
   </amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_convert_invalid_heights_attribute/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_convert_invalid_heights_attribute/expected_output.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <amp-img height="300" layout="responsive" heights="(min-width: 320px), 100vw" src="https://acme.org/image1.png" width="400" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:75.0000%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:75%"></i-amphtml-sizer>
   </amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_convert_invalid_sizes_attribute/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_convert_invalid_sizes_attribute/expected_output.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <amp-img height="300" layout="responsive" sizes="(min-width: 320px), 100vw" srcset="img-480w.jpg 480w,img-800w.jpg 800w" src="https://acme.org/image1.png" width="400" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:75.0000%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:75%"></i-amphtml-sizer>
   </amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
@@ -3,7 +3,7 @@
 </head>
 <body>
   <amp-img height="100" width="300" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:33.3333%;"></i-amphtml-sizer>
+    <i-amphtml-sizer style="display:block;padding-top:33.3333%"></i-amphtml-sizer>
   </amp-img>
 </body>
 </html>


### PR DESCRIPTION
The inline style for responsive sizers currently wastes bytes by adding fixed trailing zeroes to its value, like `80.0000%`. This PR fixes this to only use as many digits as needed for values like this, stripping any unneeded zeroes and maybe even the period.

It also strips the trailing semi-colon that is not needed after the padding to save one more byte per sizer.