### PR TITLE
Fix blurry image placeholder viewbox dimensions

### DIFF
--- a/packages/optimizer/lib/transformers/AddBlurryImagePlaceholders.js
+++ b/packages/optimizer/lib/transformers/AddBlurryImagePlaceholders.js
@@ -237,8 +237,8 @@ class AddBlurryImagePlaceholders {
     image.resize(imgDimension.width, imgDimension.height, this.jimp.RESIZE_BEZIER);
     const result = {
       src: await image.getBase64Async('image/png'),
-      width: image.bitmap.width,
-      height: image.bitmap.height,
+      width: imgDimension.width,
+      height: imgDimension.height,
     };
     return result;
   }


### PR DESCRIPTION
The blurry image format should use the downsampled image's width/height for the `viewBox`, not the original images. Using the original image's width/height can lead to black boxes around the image if the aspect ratios don't perfectly match (which is likely to happen).