### PR TITLE
Fixing https-proxy-agent checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -210,7 +210,7 @@
         "https-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "integrity": "sha512-uPiWKWb8KHXdXVi6+P2KakwzMvO1B1LLH9Hx11/mCubWbjOJMt3Xr67xnjy0shNyjokDrr3PmWID6+pKLxvJqA==",
           "requires": {
             "agent-base": "6",
             "debug": "4"


### PR DESCRIPTION
Fix for https://github.com/ampproject/amp-toolbox/issues/939
Fails `npm ci` for my project