### PR TITLE
Check if "." before extension in image URL

### DIFF
--- a/packages/cache-url/lib/ImageExtensions.js
+++ b/packages/cache-url/lib/ImageExtensions.js
@@ -145,7 +145,7 @@ const imageExtensions = [
 const exports = {
   isPathNameAnImage: (filePath) => {
     return imageExtensions.some((extension) => {
-      if (filePath.endsWith(extension)) {
+      if (filePath.endsWith(`.${extension}`)) {
         return true;
       }
       return false;


### PR DESCRIPTION
Context / Fixes #977

URLs can end with a string in `imageExtensions ` and not be an image. For example:
https://arts.visualstories.com/quizzes/know-your-art-a-trivia-on-renaissance-art 

This will check it the url also has an `.` before the extension. 

For a follow up, we should to do something like this for `isPathNameAFont` too.