### PR TITLE
Only add space between classes if preexisting class is present

### DIFF
--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -48,7 +48,8 @@ function getAttributeOrNull(element, name) {
 }
 
 function addClass(node, value) {
-  node.attribs.class = hasAttribute(node, 'class') ? node.attribs.class + ' ' + value : value;
+  const existingClass = hasAttribute(node, 'class') ? node.attribs.class.trim() : '';
+  node.attribs.class = existingClass.length > 0 ? existingClass + ' ' + value : value;
 }
 
 function apply(layout, width, height, node) {

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
@@ -7,10 +7,10 @@
     <i-amphtml-sizer style="display:block;padding-top:33.3333%"></i-amphtml-sizer>
   </amp-img>
   <!-- Auto adds responsive attribute if height, width and sizes -->
-  <amp-ad class=" i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive">
+  <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
     <!-- Auto adds responsive attribute if height, width and heights -->
-    <amp-ad class=" i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive" id="i-amp-0">
+    <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive" id="i-amp-0">
       <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
     </amp-ad>
   </amp-ad>


### PR DESCRIPTION
A change in https://github.com/ampproject/amp-toolbox/pull/1115 surfaced a problem within `addClass()` helper function, where an existing but empty `class` attribute leads to a superfluous prefixing space.

This PR changes the code in `addClass()` to account for this special case and adapts the expected spec output as required.

Fixes #1123 