### PR TITLE
Don't preload hero images

### DIFF
--- a/packages/optimizer/lib/transformers/PreloadHeroImage.js
+++ b/packages/optimizer/lib/transformers/PreloadHeroImage.js
@@ -101,9 +101,12 @@ class PreloadHeroImage {
       'as': 'image',
       'data-hero': '',
     });
-    if (heroImage.media) {
-      preload.attribs.media = heroImage.media;
+    if (!heroImage.media) {
+      // We can only safely preload a hero image if there's a media attribute
+      // as we can't detect whether it's hidden on certain viewport sizes otherwise.
+      return;
     }
+    preload.attribs.media = heroImage.media;
     insertAfter(head, preload, referenceNode);
   }
 

--- a/packages/optimizer/spec/end-to-end/body-only/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/body-only/expected_output.default.html
@@ -6,7 +6,6 @@
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script data-auto async src="https://cdn.ampproject.org/v0.js"></script>
   <script async src="https://cdn.ampproject.org/v0/amp-video-0.1.js" custom-element="amp-video"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/tokyo.jpg" as="image" data-hero>
   <link data-auto rel="canonical" href=".">
 </head>
 <body>

--- a/packages/optimizer/spec/end-to-end/body-only/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/body-only/expected_output.lts.html
@@ -6,7 +6,6 @@
   <link rel="preload" href="https://cdn.ampproject.org/lts/v0.js" as="script">
   <script data-auto async src="https://cdn.ampproject.org/lts/v0.js"></script>
   <script async src="https://cdn.ampproject.org/lts/v0/amp-video-0.1.js" custom-element="amp-video"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/tokyo.jpg" as="image" data-hero>
   <link data-auto rel="canonical" href=".">
 </head>
 <body>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.default.html
@@ -8,7 +8,6 @@
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0/amp-video-0.1.js" custom-element="amp-video"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/amp.jpg" as="image" data-hero>
   <link rel="canonical" href="self.html"><style amp-custom>h1{margin:16px}</style>
 </head>
 <body>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.lts.html
@@ -8,7 +8,6 @@
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/lts/v0/amp-video-0.1.js" custom-element="amp-video"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/lts/v0/amp-analytics-0.1.js"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/amp.jpg" as="image" data-hero>
   <link rel="canonical" href="self.html"><style amp-custom>h1{margin:16px}</style>
 </head>
 <body>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
@@ -10,7 +10,6 @@
   <script async custom-element="amp-experiment" src="https://example.com/amp/rtv/123456789000000/v0/amp-experiment-0.1.js"></script>
   <script async src="https://example.com/amp/rtv/123456789000000/v0/amp-video-0.1.js" custom-element="amp-video"></script>
   <script async custom-element="amp-analytics" src="https://example.com/amp/rtv/123456789000000/v0/amp-analytics-0.1.js"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/amp.jpg" as="image" data-hero>
   <link rel="canonical" href="self.html"><style amp-custom>h1{margin:16px}</style>
   <link rel="amphtml" href="/amp-version.html">
 </head>

--- a/packages/optimizer/spec/end-to-end/markdown/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/markdown/expected_output.default.html
@@ -5,7 +5,6 @@
   <meta data-auto name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script data-auto async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="https://octodex.github.com/images/minion.png" as="image" data-hero>
   <link data-auto rel="canonical" href=".">
 </head>
 <body>

--- a/packages/optimizer/spec/end-to-end/markdown/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/markdown/expected_output.lts.html
@@ -5,7 +5,6 @@
   <meta data-auto name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link rel="preload" href="https://cdn.ampproject.org/lts/v0.js" as="script">
   <script data-auto async src="https://cdn.ampproject.org/lts/v0.js"></script>
-  <link rel="preload" href="https://octodex.github.com/images/minion.png" as="image" data-hero>
   <link data-auto rel="canonical" href=".">
 </head>
 <body>

--- a/packages/optimizer/spec/end-to-end/story/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/story/expected_output.default.html
@@ -6,7 +6,6 @@
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/story_dog2.jpg" as="image" data-hero>
   <title>My Story</title>
   <link rel="canonical" href="helloworld.html"><style amp-custom>body {
         font-family: 'Roboto', sans-serif;

--- a/packages/optimizer/spec/end-to-end/story/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/story/expected_output.lts.html
@@ -6,7 +6,6 @@
   <link rel="preload" href="https://cdn.ampproject.org/lts/v0.js" as="script">
   <script async src="https://cdn.ampproject.org/lts/v0.js"></script>
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/lts/v0/amp-story-1.0.js"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/story_dog2.jpg" as="image" data-hero>
   <title>My Story</title>
   <link rel="canonical" href="helloworld.html"><style amp-custom>body {
         font-family: 'Roboto', sans-serif;

--- a/packages/optimizer/spec/end-to-end/story/expected_output.paired.html
+++ b/packages/optimizer/spec/end-to-end/story/expected_output.paired.html
@@ -6,7 +6,6 @@
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-  <link rel="preload" href="https://amp.dev/static/samples/img/story_dog2.jpg" as="image" data-hero>
   <title>My Story</title>
   <link rel="canonical" href="helloworld.html"><style amp-custom>body {
         font-family: 'Roboto', sans-serif;

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-iframe_data-hero/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-iframe_data-hero/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="hero.jpg" as="image" data-hero>
 </head>
 <body>
   <amp-iframe src="/no-hero" layout="responsive" width="320" height="900">

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-img-object-fit-object-position/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-img-object-fit-object-position/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="https://amp.dev/static/img/icons/icon-512x512.png" as="image" data-hero>
 </head>
 <body>
   <!-- object-fit and object-position should be rewritten to inline styles -->

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-img/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-img/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-video_with_poster/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/amp-video_with_poster/expected_output.html
@@ -1,7 +1,5 @@
 <html>
-<head>
-  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
-</head>
+<head></head>
 <body>
   <amp-video poster="https://example-com.cdn.ampproject.org/foo.png" width="400" height="400">
     <source src="foo.mp4">

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/data-hero_amp-img/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/data-hero_amp-img/expected_output.html
@@ -1,8 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/hero1.png" as="image" data-hero>
-  <link rel="preload" href="/hero2.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="500" height="400" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/data-hero_amp-img_maximum/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/data-hero_amp-img_maximum/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/hero-foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="500" height="400" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/fixed/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/fixed/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimensions_from_parent_container/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/hero_image_dimensions_from_parent_container/expected_output.html
@@ -1,7 +1,5 @@
 <html>
-<head>
-  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
-</head>
+<head></head>
 <body>
   <div width="500" height="500">
     <amp-img layout="fill" src="https://example-com.cdn.ampproject.org/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_data_uris_amp-iframe/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_data_uris_amp-iframe/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="http://example.com/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-iframe src="/test" layout="responsive" width="320" height="900">

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_data_uris_amp-img/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_data_uris_amp-img/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="500" height="400" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_data_uris_amp-video/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_data_uris_amp-video/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="https://example.com/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-video poster="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" width="400" height="400">

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_non_image_preloads/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_non_image_preloads/expected_output.html
@@ -2,7 +2,6 @@
 <head>
   <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_tiny_images_intrinsic/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_tiny_images_intrinsic/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/big.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="32" height="32" src="/small.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_tiny_images_responsive/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/ignores_tiny_images_responsive/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/big.png" as="image" data-hero>
 </head>
 <body>
   <amp-img width="32" height="32" src="/small.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/intrinsic-layout/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/intrinsic-layout/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img layout="intrinsic" width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/responsive-layout/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/responsive-layout/expected_output.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <link rel="preload" href="/foo.png" as="image" data-hero>
 </head>
 <body>
   <amp-img layout="responsive" width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/same_as_above_with_nodisplay_layout_removed/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/same_as_above_with_nodisplay_layout_removed/expected_output.html
@@ -1,7 +1,5 @@
 <html>
-<head>
-  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
-</head>
+<head></head>
 <body>
   <amp-img height="500" src="https://example-com.cdn.ampproject.org/foo.png" width="500" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
 </body>

--- a/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_validity_empty_srcset/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/PreloadHeroImage/srcset_validity_empty_srcset/expected_output.html
@@ -1,7 +1,5 @@
 <html>
-<head>
-  <link rel="preload" href="https://example-com.cdn.ampproject.org/foo.png" as="image" data-hero>
-</head>
+<head></head>
 <body>
   <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset i-amphtml-ssr data-hero>
     <img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset>


### PR DESCRIPTION
We can't tell whether a hero image is responsive and is loaded depending
on viewport size. The current implementation will always preload hero
images, which means images might be preloaded even if they are not
visible on the page. This PR reverts this behavior and disables
preload generation for hero images.

The only exception is when an image defines a media attribute.