### PR TITLE
Add missing amp-ad ending tag

### DIFF
--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
@@ -9,10 +9,10 @@
   <!-- Auto adds responsive attribute if height, width and sizes -->
   <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
-    <!-- Auto adds responsive attribute if height, width and heights -->
-    <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive" id="i-amp-0">
-      <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
-    </amp-ad>
+  </amp-ad>
+  <!-- Auto adds responsive attribute if height, width and heights -->
+  <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive" id="i-amp-0">
+    <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
   </amp-ad>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/input.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/input.html
@@ -20,6 +20,7 @@
       data-article=auto
       data-target_type=mix
     >
+    </amp-ad>
     <!-- Auto adds responsive attribute if height, width and heights -->
     <amp-ad
       class=""
@@ -34,6 +35,6 @@
       data-article=auto
       data-target_type=mix
     >
-</amp-ad>
+    </amp-ad>
   </body>
 </html>


### PR DESCRIPTION
The `input.html` file in the `ServerSideRendering/transforms_layout_responsive` spec test is missing an ending tag for one of the `<amp-ad>` elements, which messes up the test output.