### PR TITLE
Show blurredPlaceholders warning only when enabled

### DIFF
--- a/packages/optimizer/lib/transformers/AddBlurryImagePlaceholders.js
+++ b/packages/optimizer/lib/transformers/AddBlurryImagePlaceholders.js
@@ -77,10 +77,12 @@ class AddBlurryImagePlaceholders {
     // generation at runtime
     this.missingDependencies_ = false;
     if (!isDependencyInstalled('jimp') || !isDependencyInstalled('lru-cache')) {
-      this.log_.warn(
-        'jimp and lru-cache need to be installed via `npm install jimp lru-cache` ' +
-          'for this transformer to work'
-      );
+      if (this.blurredPlaceholders_) {
+        this.log_.warn(
+          'jimp and lru-cache need to be installed via `npm install jimp lru-cache` ' +
+            'for this transformer to work'
+        );
+      }
       // we can't generate placeholders
       this.blurredPlaceholders_ = false;
       this.missingDependencies_ = true;


### PR DESCRIPTION
### Overview

Hi there!

I found that the warning of blurredPlaceholders was shown even if  blurredPlaceholders option was disabled.
https://github.com/ampproject/amp-toolbox/tree/main/packages/optimizer#blurry-image-placeholders

```
AMP Optimizer AddBlurryImagePlaceholders WARNING jimp and lru-cache need to be installed via `npm install jimp lru-cache` for this transformer to work
```

I don't think there is a need to show the waring when the option is disabled.
So, I change that the waring is shown only when the option is enabled. 