### PR TITLE
Remove hard-coded isTiny() result for intrinsic layout

### DIFF
--- a/packages/optimizer/lib/transformers/OptimizeHeroImages.js
+++ b/packages/optimizer/lib/transformers/OptimizeHeroImages.js
@@ -290,7 +290,7 @@ class OptimizeHeroImage {
   // Any node with width or height less than 150 pixels and a non-responsive layout.
   isTinyNode(layout, width, height) {
     if (width <= 0 || height <= 0) return true;
-    if (layout === 'intrinsic' || layout === 'responsive') {
+    if (layout === 'responsive') {
       return false;
     }
     return width < TINY_IMG_THRESHOLD || height < TINY_IMG_THRESHOLD;

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_tiny_images_intrinsic/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_tiny_images_intrinsic/expected_output.html
@@ -4,6 +4,6 @@
 </head>
 <body>
   <amp-img width="32" height="32" src="/small.png"></amp-img>
-  <amp-img width="16" height="9" layout="intrinsic" src="/big.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/big.png"></amp-img>
+  <amp-img width="16" height="9" layout="intrinsic" src="/big.png"></amp-img>
 </body>
 </html>


### PR DESCRIPTION
There is an error in the isTiny() where the width & height are ignored for an intrinsic layout. This is not correct, as for the intrinsic layout, the image is shrinking to fit the container, but can only grow up to the maximum of its width and height attributes. So if these are below the isTiny() threshold, it should be flagged accordingly.

> Related PR in the PHP toolbox: https://github.com/ampproject/amp-toolbox-php/pull/115