### PR TITLE
Make ES modules option consistent

### DIFF
--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -157,22 +157,6 @@ Specifies the AMP format of the input file. Defaults to `AMP`.
 - default: `AMP`
 - used by: [AutoExtensionImport](lib/transformers/AutoExtensionImporter.js), [AddMandatoryTags](lib/transformers/AddMandatoryTags.js)
 
-#### `experimentEsm`
-
-Enable [JavaScript Module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) support for AMP runtime and components. AMP Optimizer will generate module/nonmodule script imports for AMP runtime and components:
-
-```
-<script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
-<script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
-```
-
-**Warning: this will result in invalid AMP pages.**
-
-- name: `experimentEsm`
-- valid options: `[true|false]`
-- default: `false`
-- used by: [RewriteAmpUrls](lib/transformers/RewriteAmpUrls.js)
-
 #### `imageBasePath`
 
 Specifies a base path used to resolve an image during build,

--- a/packages/optimizer/lib/transformers/RewriteAmpUrls.js
+++ b/packages/optimizer/lib/transformers/RewriteAmpUrls.js
@@ -47,6 +47,9 @@ const {calculateHost} = require('../RuntimeHostHelper');
  *   option is ineffective with the lts flag, but will simply be ignored
  *   rather than throwing an error.
  *
+ * * `esmModulesEnabled`: Enables the smaller ESM module version of AMP runtime
+ *   and components.
+ *
  * All parameters are optional. If no option is provided, runtime URLs won't be
  * re-written. You can combine `ampRuntimeVersion` and  `ampUrlPrefix` to
  * rewrite AMP runtime URLs to versioned URLs on a different origin.

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/config.json
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/config.json
@@ -1,3 +1,3 @@
 {
-  "useEsmModules": true
+  "esmModulesEnabled": true
 }

--- a/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/config.json
+++ b/packages/optimizer/spec/transformers/experimental/RewriteAmpUrls/config.json
@@ -1,3 +1,3 @@
 {
-  "experimentEsm": true
+  "useEsmModules": true
 }

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_esm/input.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_esm/input.html
@@ -1,3 +1,8 @@
+<!--
+{
+  "esmModulesEnabled": true
+}
+-->
 <!doctype html>
 <html ⚡>
 <head>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_lts/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_lts/expected_output.html
@@ -1,14 +1,12 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <script async nomodule src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
-  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <script async nomodule src="https://cdn.ampproject.org/lts/v0.js"></script>
-  <script async src="https://cdn.ampproject.org/lts/v0.mjs" type="module" crossorigin="anonymous"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/lts/v0.js"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/lts/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/lts/v0.mjs" rel="modulepreload">
+  <link rel="preload" href="https://cdn.ampproject.org/lts/v0.js" as="script">
   <link rel="preload" href="https://cdn.ampproject.org/lts/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_preloads/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_preloads/expected_output.html
@@ -1,14 +1,12 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
-  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
-  <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
 </head>
 <body></body>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/config.json
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/config.json
@@ -1,0 +1,3 @@
+{
+  "esmModulesEnabled": false
+}


### PR DESCRIPTION
ES modules were changed to be used by default in the following PR: https://github.com/ampproject/amp-toolbox/pull/1140

This also seems to have changed the config setting from `experimentEsm` to `esmModulesEnabled`.

However, the `experimentEsm` option was not replaced everywhere, and the class docblock of the `RewriteAmpUrls` transformer even documented both.

The config being set in some of the spec tests is still using `experimentEsm`, even though that has no function anymore. The fact that the tests still pass is only due to the change of the default from `false` to `true`.