### PR TITLE
correct the amp version output

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -120,5 +120,5 @@ Prints the current AMP Toolbox version:
 ```shell
 $ amp version
 
-=> 011905291911450
+=> v2.7.6
 ```


### PR DESCRIPTION
`amp version` example output is not the same as the `amp runtime-version` output. It should reflect the version of the CLI tool, and not the browser runtime.