### PR TITLE
Prevent SSR for amp-img occurring after second paragraph

### DIFF
--- a/packages/optimizer/lib/transformers/OptimizeHeroImages.js
+++ b/packages/optimizer/lib/transformers/OptimizeHeroImages.js
@@ -145,12 +145,17 @@ class OptimizeHeroImage {
     let heroImageCandidate = null;
     let heroImages = [];
     let node = root;
+    let seenParagraphCount = 0;
     // Walk over all nodes in the body
     while (node !== null) {
+      if (node.tagName === 'p') {
+        seenParagraphCount++;
+      }
       // Look for data-hero attribute
       this.addImageWithDataHero(node, heroImages);
-      // Auto detect a hero image in case data-hero is not used
-      if (!heroImageCandidate && heroImages.length === 0) {
+      // Auto detect a hero image in case data-hero is not used,
+      // but only if before the second paragraph.
+      if (!heroImageCandidate && seenParagraphCount < 2 && heroImages.length === 0) {
         heroImageCandidate = this.isCandidateHeroImage(node);
       }
       if (isTemplate(node)) {

--- a/packages/optimizer/lib/transformers/OptimizeHeroImages.js
+++ b/packages/optimizer/lib/transformers/OptimizeHeroImages.js
@@ -322,12 +322,21 @@ class OptimizeHeroImage {
       return;
     }
     node.attribs['i-amphtml-ssr'] = '';
-    node.attribs['data-hero'] = '';
+
     // Create img node
     const imgNode = createElement('img', {
       class: 'i-amphtml-fill-content i-amphtml-replaced-content',
       decoding: 'async',
     });
+
+    // If the image was detected as hero image candidate (and thus lacks an explicit
+    // data-hero), mark it as a hero and add loading=lazy to guard against making
+    // the page performance even worse by eagerly loading an image outside the viewport.
+    if (!('data-hero' in node.attribs)) {
+      node.attribs['data-hero'] = '';
+      imgNode.attribs['loading'] = 'lazy';
+    }
+
     // Copy attributes
     const attributesToCopy = [
       'alt',

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.default.html
@@ -17,7 +17,7 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.lts.html
@@ -17,7 +17,7 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.minimal.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.minimal.html
@@ -17,7 +17,7 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>

--- a/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
+++ b/packages/optimizer/spec/end-to-end/hello-world/expected_output.paired.html
@@ -20,7 +20,7 @@
 <body>
   <h1>Hello, AMP world!</h1>
   <amp-img src="https://amp.dev/static/samples/img/amp.jpg" width="1080" height="610" layout="responsive" i-amphtml-ssr data-hero class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
-    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://amp.dev/static/samples/img/amp.jpg">
+    <i-amphtml-sizer style="display:block;padding-top:56.4815%"></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://amp.dev/static/samples/img/amp.jpg">
   </amp-img>
   <amp-video width="480" height="270" src="https://amp.dev/static/samples/video/tokyo.mp4" poster="https://amp.dev/static/samples/img/tokyo.jpg" layout="responsive" controls class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:56.25%"></i-amphtml-sizer>

--- a/packages/optimizer/spec/end-to-end/markdown/expected_output.default.html
+++ b/packages/optimizer/spec/end-to-end/markdown/expected_output.default.html
@@ -163,8 +163,8 @@ line 3 of code
   </p>
   <h2>Images</h2>
   <p>
-    <amp-img src="https://octodex.github.com/images/minion.png" alt="Minion" width="896" height="896" layout="intrinsic" i-amphtml-ssr data-hero class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
-      <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijg5NiIgd2lkdGg9Ijg5NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" alt="Minion" src="https://octodex.github.com/images/minion.png">
+    <amp-img src="https://octodex.github.com/images/minion.png" alt="Minion" width="896" height="896" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
+      <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijg5NiIgd2lkdGg9Ijg5NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer>
     </amp-img>
     <amp-img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" width="704" height="676" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
       <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjY3NiIgd2lkdGg9IjcwNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer>

--- a/packages/optimizer/spec/end-to-end/markdown/expected_output.lts.html
+++ b/packages/optimizer/spec/end-to-end/markdown/expected_output.lts.html
@@ -163,8 +163,8 @@ line 3 of code
   </p>
   <h2>Images</h2>
   <p>
-    <amp-img src="https://octodex.github.com/images/minion.png" alt="Minion" width="896" height="896" layout="intrinsic" i-amphtml-ssr data-hero class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
-      <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijg5NiIgd2lkdGg9Ijg5NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" alt="Minion" src="https://octodex.github.com/images/minion.png">
+    <amp-img src="https://octodex.github.com/images/minion.png" alt="Minion" width="896" height="896" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
+      <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijg5NiIgd2lkdGg9Ijg5NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer>
     </amp-img>
     <amp-img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" width="704" height="676" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
       <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjY3NiIgd2lkdGg9IjcwNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer>

--- a/packages/optimizer/spec/end-to-end/markdown/expected_output.minimal.html
+++ b/packages/optimizer/spec/end-to-end/markdown/expected_output.minimal.html
@@ -191,8 +191,8 @@ line 3 of code
   </p>
   <h2>Images</h2>
   <p>
-    <amp-img src="https://octodex.github.com/images/minion.png" alt="Minion" width="896" height="896" layout="intrinsic" i-amphtml-ssr data-hero class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
-      <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijg5NiIgd2lkdGg9Ijg5NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" alt="Minion" src="https://octodex.github.com/images/minion.png">
+    <amp-img src="https://octodex.github.com/images/minion.png" alt="Minion" width="896" height="896" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
+      <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijg5NiIgd2lkdGg9Ijg5NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer>
     </amp-img>
     <amp-img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" width="704" height="676" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
       <i-amphtml-sizer class="i-amphtml-sizer"><img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjY3NiIgd2lkdGg9IjcwNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="></i-amphtml-sizer>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-iframe/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-iframe/expected_output.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <amp-iframe src="/test" layout="responsive" width="320" height="900" media="(max-width: 649px)">
-    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="http://example.com/foo.png"></amp-img>
+    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="http://example.com/foo.png"></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-iframe_data-hero/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-iframe_data-hero/expected_output.html
@@ -7,7 +7,7 @@
     <amp-img placeholder layout="fill" src="no-hero.jpg"></amp-img>
   </amp-iframe>
   <amp-iframe data-hero src="/hero" layout="responsive" width="320" height="900">
-    <amp-img placeholder layout="fill" src="hero.jpg" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="hero.jpg"></amp-img>
+    <amp-img placeholder layout="fill" src="hero.jpg" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="hero.jpg"></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img/expected_output.html
@@ -3,6 +3,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_after_first_paragraph/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_after_first_paragraph/expected_output.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci
+    sit amet congue fermentum, justo felis volutpat ligula, ac placerat elit sem
+    vel elit. Nam pharetra nibh eget varius auctor. Cras quis enim tincidunt,
+    sodales turpis eget, molestie velit. Proin efficitur dapibus faucibus. Morbi
+    viverra leo nec gravida venenatis. Suspendisse potenti. Maecenas vitae
+    consectetur velit. Sed fringilla augue eu viverra hendrerit. Maecenas sed arcu
+    ut sapien sodales fringilla in et sapien. Donec et auctor leo. Donec eget erat
+    aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
+    at blandit eros semper.
+  </p>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_after_first_paragraph/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_after_first_paragraph/expected_output.html
@@ -14,6 +14,6 @@
     aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
     at blandit eros semper.
   </p>
-  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_after_first_paragraph/input.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_after_first_paragraph/input.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci
+    sit amet congue fermentum, justo felis volutpat ligula, ac placerat elit sem
+    vel elit. Nam pharetra nibh eget varius auctor. Cras quis enim tincidunt,
+    sodales turpis eget, molestie velit. Proin efficitur dapibus faucibus. Morbi
+    viverra leo nec gravida venenatis. Suspendisse potenti. Maecenas vitae
+    consectetur velit. Sed fringilla augue eu viverra hendrerit. Maecenas sed arcu
+    ut sapien sodales fringilla in et sapien. Donec et auctor leo. Donec eget erat
+    aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
+    at blandit eros semper.
+  </p>
+  <amp-img width="500" height="400" src="/foo.png"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_first_paragraph/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_first_paragraph/expected_output.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <p>
+    <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci
+    sit amet congue fermentum, justo felis volutpat ligula, ac placerat elit sem
+    vel elit. Nam pharetra nibh eget varius auctor. Cras quis enim tincidunt,
+    sodales turpis eget, molestie velit. Proin efficitur dapibus faucibus. Morbi
+    viverra leo nec gravida venenatis. Suspendisse potenti. Maecenas vitae
+    consectetur velit. Sed fringilla augue eu viverra hendrerit. Maecenas sed arcu
+    ut sapien sodales fringilla in et sapien. Donec et auctor leo. Donec eget erat
+    aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
+    at blandit eros semper.
+  </p>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_first_paragraph/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_first_paragraph/expected_output.html
@@ -4,7 +4,7 @@
 </head>
 <body>
   <p>
-    <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+    <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
   </p>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_first_paragraph/input.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_first_paragraph/input.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <p>
+    <amp-img width="500" height="400" src="/foo.png"></amp-img>
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci
+    sit amet congue fermentum, justo felis volutpat ligula, ac placerat elit sem
+    vel elit. Nam pharetra nibh eget varius auctor. Cras quis enim tincidunt,
+    sodales turpis eget, molestie velit. Proin efficitur dapibus faucibus. Morbi
+    viverra leo nec gravida venenatis. Suspendisse potenti. Maecenas vitae
+    consectetur velit. Sed fringilla augue eu viverra hendrerit. Maecenas sed arcu
+    ut sapien sodales fringilla in et sapien. Donec et auctor leo. Donec eget erat
+    aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
+    at blandit eros semper.
+  </p>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_second_paragraph/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_second_paragraph/expected_output.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci
+    sit amet congue fermentum, justo felis volutpat ligula, ac placerat elit sem
+    vel elit. Nam pharetra nibh eget varius auctor. Cras quis enim tincidunt,
+    sodales turpis eget, molestie velit. Proin efficitur dapibus faucibus. Morbi
+    viverra leo nec gravida venenatis. Suspendisse potenti. Maecenas vitae
+    consectetur velit. Sed fringilla augue eu viverra hendrerit. Maecenas sed arcu
+    ut sapien sodales fringilla in et sapien. Donec et auctor leo. Donec eget erat
+    aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
+    at blandit eros semper.
+  </p>
+  <p>
+    <amp-img width="500" height="400" src="/foo.png"></amp-img>
+  </p>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_second_paragraph/input.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_in_second_paragraph/input.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin aliquet, orci
+    sit amet congue fermentum, justo felis volutpat ligula, ac placerat elit sem
+    vel elit. Nam pharetra nibh eget varius auctor. Cras quis enim tincidunt,
+    sodales turpis eget, molestie velit. Proin efficitur dapibus faucibus. Morbi
+    viverra leo nec gravida venenatis. Suspendisse potenti. Maecenas vitae
+    consectetur velit. Sed fringilla augue eu viverra hendrerit. Maecenas sed arcu
+    ut sapien sodales fringilla in et sapien. Donec et auctor leo. Donec eget erat
+    aliquet, fermentum ante quis, varius risus. Nam luctus ipsum eget diam congue,
+    at blandit eros semper.
+  </p>
+  <p>
+    <amp-img width="500" height="400" src="/foo.png"></amp-img>
+  </p>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/attributes/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/attributes/expected_output.html
@@ -3,6 +3,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img width="500" height="400" alt="Some image" attribution="by someone" referrerpolicy="unknown" src="foo.jpg" srcset="for2.jpg w320, foo3.jpg" sizes="many" title="the title" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" alt="Some image" attribution="by someone" referrerpolicy="unknown" src="foo.jpg" srcset="for2.jpg w320, foo3.jpg" sizes="many" title="the title"></amp-img>
+  <amp-img width="500" height="400" alt="Some image" attribution="by someone" referrerpolicy="unknown" src="foo.jpg" srcset="for2.jpg w320, foo3.jpg" sizes="many" title="the title" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" alt="Some image" attribution="by someone" referrerpolicy="unknown" src="foo.jpg" srcset="for2.jpg w320, foo3.jpg" sizes="many" title="the title"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/does_not_duplicate_existing_image_preload/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/does_not_duplicate_existing_image_preload/expected_output.html
@@ -4,6 +4,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/fixed/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/fixed/expected_output.html
@@ -3,6 +3,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/hero_image_dimensions_from_parent_container/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/hero_image_dimensions_from_parent_container/expected_output.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
   <div width="500" height="500">
-    <amp-img layout="fill" src="https://example-com.cdn.ampproject.org/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
+    <amp-img layout="fill" src="https://example-com.cdn.ampproject.org/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
   </div>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_data_uris_amp-iframe/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_data_uris_amp-iframe/expected_output.html
@@ -7,7 +7,7 @@
     <amp-img placeholder layout="fill" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="></amp-img>
   </amp-iframe>
   <amp-iframe src="/test" layout="responsive" width="320" height="900">
-    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="http://example.com/foo.png"></amp-img>
+    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="http://example.com/foo.png"></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_data_uris_amp-img/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_data_uris_amp-img/expected_output.html
@@ -4,6 +4,6 @@
 </head>
 <body>
   <amp-img width="500" height="400" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="></amp-img>
-  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_non_image_preloads/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_non_image_preloads/expected_output.html
@@ -4,6 +4,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_tiny_images_responsive/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/ignores_tiny_images_responsive/expected_output.html
@@ -4,6 +4,6 @@
 </head>
 <body>
   <amp-img width="32" height="32" src="/small.png"></amp-img>
-  <amp-img width="16" height="9" layout="responsive" src="/big.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/big.png"></amp-img>
+  <amp-img width="16" height="9" layout="responsive" src="/big.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/big.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/intrinsic-layout/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/intrinsic-layout/expected_output.html
@@ -3,6 +3,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img layout="intrinsic" width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img layout="intrinsic" width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/media_attribute_amp-iframe/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/media_attribute_amp-iframe/expected_output.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <amp-iframe src="/test" layout="responsive" width="320" height="900" media="(max-width: 649px)">
-    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="http://example.com/foo.png"></amp-img>
+    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="http://example.com/foo.png"></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/media_attribute_amp-img/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/media_attribute_amp-img/expected_output.html
@@ -4,6 +4,6 @@
   <link rel="preload" href="/foo.png" as="image" data-hero media="(max-width: 649px)">
 </head>
 <body>
-  <amp-img width="500" height="400" src="/foo.png" media="(max-width: 649px)" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img width="500" height="400" src="/foo.png" media="(max-width: 649px)" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/media_attribute_amp-video-iframe/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/media_attribute_amp-video-iframe/expected_output.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <amp-video-iframe src="/test" layout="responsive" width="320" height="900" media="(max-width: 649px)">
-    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="http://example.com/foo.png"></amp-img>
+    <amp-img placeholder layout="fill" src="http://example.com/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="http://example.com/foo.png"></amp-img>
   </amp-video-iframe>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/responsive-layout/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/responsive-layout/expected_output.html
@@ -3,6 +3,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-img layout="responsive" width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/foo.png"></amp-img>
+  <amp-img layout="responsive" width="500" height="400" src="/foo.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/same_as_above_with_nodisplay_layout_removed/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/same_as_above_with_nodisplay_layout_removed/expected_output.html
@@ -1,6 +1,6 @@
 <html>
 <head></head>
 <body>
-  <amp-img height="500" src="https://example-com.cdn.ampproject.org/foo.png" width="500" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
+  <amp-img height="500" src="https://example-com.cdn.ampproject.org/foo.png" width="500" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/srcset_cannot_be_preloaded/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/srcset_cannot_be_preloaded/expected_output.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
   <!-- srcset is not supported by all browsers -->
-  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr"></amp-img>
+  <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://example-com.cdn.ampproject.org/foo.png" srcset="test 100w test2 3dpr"></amp-img>
   <!-- not preloaded as it's not a hero image -->
   <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png"></amp-img>
 </body>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/srcset_validity_empty_srcset/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/srcset_validity_empty_srcset/expected_output.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
   <amp-img width="500" height="400" src="https://example-com.cdn.ampproject.org/foo.png" srcset i-amphtml-ssr data-hero>
-    <img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="https://example-com.cdn.ampproject.org/foo.png" srcset>
+    <img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="https://example-com.cdn.ampproject.org/foo.png" srcset>
   </amp-img>
 </body>
 </html>


### PR DESCRIPTION
As pointed out by @jono-alderson, hero image prerendering can be detrimental when there are no hero images in the first viewport, as seen in these two examples from amp-wp.org:

[Blog post](https://amp-wp.org/building-amp-first-websites-with-wordpress-a-roadmap/) | [Homepage](https://amp-wp.org/)
-------------------------------------------------------------------------------------------|----------------------
![image](https://user-images.githubusercontent.com/134745/114222872-f6e46380-9923-11eb-8f29-81b56d57134e.png) | ![image](https://user-images.githubusercontent.com/134745/114222787-dd431c00-9923-11eb-9a05-799ddf3e2dc1.png)

This is especially problematic because `OptimizeHeroImage` does not include `loading=lazy` on the SSR'ed image. The result is that an optimized page may actually perform _worse_. 

This PR mitigates this issue by only doing hero image prerendering for images that appear before the second paragraph in the page.

Another mitigation measure is to add `loading=lazy` to any SSR'ed hero image that was automatically detected. If a document had `data-hero` on an image up front then the `loading=lazy` would remain omitted since the author is explicitly assuring the optimizer that the image should indeed be in the first viewport.