### PR TITLE
Improve logic to detect explicitly marked hero images

### DIFF
--- a/packages/optimizer/lib/transformers/OptimizeHeroImages.js
+++ b/packages/optimizer/lib/transformers/OptimizeHeroImages.js
@@ -332,9 +332,12 @@ class OptimizeHeroImage {
     // If the image was detected as hero image candidate (and thus lacks an explicit
     // data-hero), mark it as a hero and add loading=lazy to guard against making
     // the page performance even worse by eagerly loading an image outside the viewport.
+    if (!this.isMarkedAsHeroImage(node)) {
+      imgNode.attribs['loading'] = 'lazy';
+    }
+
     if (!('data-hero' in node.attribs)) {
       node.attribs['data-hero'] = '';
-      imgNode.attribs['loading'] = 'lazy';
     }
 
     // Copy attributes
@@ -366,6 +369,25 @@ class OptimizeHeroImage {
       imgNode.attribs.style = styles.join(';');
     }
     appendChild(node, imgNode);
+  }
+
+  isMarkedAsHeroImage(node) {
+    while (node) {
+      if (!node.tagName) {
+        node = node.parent;
+      }
+
+      if ('data-hero' in node.attribs) {
+        return true;
+      }
+
+      if (node.tagName === 'body' || node.tagName === 'html') {
+        return false;
+      }
+
+      node = node.parent;
+    }
+    return false;
   }
 }
 

--- a/packages/optimizer/lib/transformers/OptimizeHeroImages.js
+++ b/packages/optimizer/lib/transformers/OptimizeHeroImages.js
@@ -375,6 +375,7 @@ class OptimizeHeroImage {
     while (node) {
       if (!node.tagName) {
         node = node.parent;
+        continue;
       }
 
       if ('data-hero' in node.attribs) {

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-iframe_data-hero/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-iframe_data-hero/expected_output.html
@@ -7,7 +7,7 @@
     <amp-img placeholder layout="fill" src="no-hero.jpg"></amp-img>
   </amp-iframe>
   <amp-iframe data-hero src="/hero" layout="responsive" width="320" height="900">
-    <amp-img placeholder layout="fill" src="hero.jpg" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="hero.jpg"></amp-img>
+    <amp-img placeholder layout="fill" src="hero.jpg" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="hero.jpg"></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/img1.png" data-hero i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/img1.png"></amp-img>
+  <amp-img width="500" height="400" src="/img2.png" data-hero i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/img2.png"></amp-img>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/input.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/input.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/img1.png" data-hero><noscript><img src="/img1.png" width="500" height="400" loading="lazy"></noscript></amp-img>
+  <amp-img width="500" height="400" src="/img2.png" data-hero><noscript><img src="/img2.png" width="500" height="400"></noscript></amp-img>
+</body>
+</html>


### PR DESCRIPTION
The logic in https://github.com/ampproject/amp-toolbox/pull/1196 fails to properly detect a nested construct, like if an iframe if marked with `data-hero` and its placeholder image is SSRed.

This PR improves the logic to properly detect these cases.