### PR TITLE
Run format

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:optimizer:snapshot": "OPTIMIZER_SNAPSHOT=true jest",
     "test:page-experience:snapshot": "PAGE_EXPERIENCE_SNAPSHOT=true jest",
     "test:browser": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
-    "format": "prettier --config=prettier.config.js --write **/*.{js,ts}",
+    "format": "prettier --config=prettier.config.js --write '**/*.{js,ts}'",
     "lint": "eslint  -c .eslintrc.json .",
     "lint:fix": "eslint  -c .eslintrc.json --fix '**/*.{js,ts}'"
   },

--- a/packages/linter/demo/index.js
+++ b/packages/linter/demo/index.js
@@ -1,8 +1,8 @@
-const { lint } = require("../dist/index");
-const cheerio = require("cheerio");
-const fetch = require("node-fetch");
+const {lint} = require('../dist/index');
+const cheerio = require('cheerio');
+const fetch = require('node-fetch');
 
-lintDocument("https://amp.dev");
+lintDocument('https://amp.dev');
 
 async function lintDocument(url) {
   const body = await fetchDocument(url);
@@ -12,10 +12,10 @@ async function lintDocument(url) {
     $: cheerio.load(body),
     raw: {
       headers: {},
-      body
+      body,
     },
     headers: {},
-    mode: "amp"
+    mode: 'amp',
   };
 
   const result = await lint(context);

--- a/packages/linter/src/caches.ts
+++ b/packages/linter/src/caches.ts
@@ -1,8 +1,8 @@
-import { existsSync, readFileSync } from "fs";
-import AmpCacheList from "@ampproject/toolbox-cache-list";
+import {existsSync, readFileSync} from 'fs';
+import AmpCacheList from '@ampproject/toolbox-cache-list';
 
-const cacheList = (existsSync("caches.json")
-  ? Promise.resolve(JSON.parse(readFileSync("caches.json").toString()).caches)
+const cacheList = (existsSync('caches.json')
+  ? Promise.resolve(JSON.parse(readFileSync('caches.json').toString()).caches)
   : new AmpCacheList().list()) as Promise<
   Array<{
     cacheDomain: string;

--- a/packages/linter/src/cli.ts
+++ b/packages/linter/src/cli.ts
@@ -1,65 +1,56 @@
-import { readFileSync } from "fs";
-import { isArray } from "util";
-import program from "commander";
-import fetch from "node-fetch";
-import cheerio from "cheerio";
-import chalk from "chalk";
-import { lint, Result, LintMode, guessMode, Status, StatusNumber } from ".";
-import { fetchToCurl } from "./helper";
+import {readFileSync} from 'fs';
+import {isArray} from 'util';
+import program from 'commander';
+import fetch from 'node-fetch';
+import cheerio from 'cheerio';
+import chalk from 'chalk';
+import {lint, Result, LintMode, guessMode, Status, StatusNumber} from '.';
+import {fetchToCurl} from './helper';
 // import { version } from "../package.json";
 
 const UA = {
   googlebot_mobile: [
-    "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36",
-    "(KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36",
-    "(compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-  ].join(" "),
+    'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36',
+    '(KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36',
+    '(compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+  ].join(' '),
   googlebot_desktop: [
-    "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible;",
-    "Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36",
-  ].join(" "),
+    'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible;',
+    'Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36',
+  ].join(' '),
   chrome_mobile: [
-    "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012)",
-    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Mobile Safari/537.36",
-  ].join(" "),
+    'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012)',
+    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Mobile Safari/537.36',
+  ].join(' '),
   chrome_desktop: [
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3)",
-    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36",
-  ].join(" "),
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3)',
+    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36',
+  ].join(' '),
 };
 
-export function cli(argv: string[], logger = console, cmd = "amplint") {
+export function cli(argv: string[], logger = console, cmd = 'amplint') {
   program
     .storeOptionsAsProperties()
     // .version(version)
     .usage(`${cmd} [options] URL|copy_as_cURL`)
     .option(
       `-f, --force <string>`,
-      "override test type",
+      'override test type',
       /^(auto|sxg|amp|ampstory|pageexperience)$/i, // needs to be of type LintMode | "auto"
-      "auto"
+      'auto'
     )
-    .option(
-      `-t, --format <string>`,
-      "override output format",
-      /^(text|json|tsv|html)$/i,
-      "text"
-    )
+    .option(`-t, --format <string>`, 'override output format', /^(text|json|tsv|html)$/i, 'text')
     .option(
       `-A, --user-agent <string>`,
-      "user agent string",
+      'user agent string',
       /^(googlebot_desktop|googlebot_mobile|chrome_desktop|chrome_mobile)$/i,
-      "googlebot_mobile"
+      'googlebot_mobile'
     )
-    .option(`-s, --show-passing`, "show passing tests in output", false)
-    .option(
-      `-r, --report-mode`,
-      "include metadata for passing tests in output",
-      false
-    )
-    .on("--help", function () {
-      logger.log("");
-      logger.log("Examples:");
+    .option(`-s, --show-passing`, 'show passing tests in output', false)
+    .option(`-r, --report-mode`, 'include metadata for passing tests in output', false)
+    .on('--help', function () {
+      logger.log('');
+      logger.log('Examples:');
       logger.log(`  $ ${cmd} https://amp.dev/`);
       logger.log(`  $ ${cmd} --force sxg https://amp.dev/`);
     });
@@ -80,14 +71,14 @@ export function cli(argv: string[], logger = console, cmd = "amplint") {
 
   // One reason to support curl-style arguments is to provide cookies that avoid
   // GDPR interstitials.
-  const headers: { [k: string]: string } = seq(2, argv.length - 1)
-    .filter((n) => argv[n] === "-H")
+  const headers: {[k: string]: string} = seq(2, argv.length - 1)
+    .filter((n) => argv[n] === '-H')
     .map((n) => argv[n + 1])
     .map((s) => {
-      const [h, ...v] = s.split(": ");
-      return [h, v.join("")];
+      const [h, ...v] = s.split(': ');
+      return [h, v.join('')];
     })
-    .reduce((a: { [key: string]: any }, kv) => {
+    .reduce((a: {[key: string]: any}, kv) => {
       a[kv[0]] = kv[1];
       return a;
     }, {});
@@ -95,9 +86,7 @@ export function cli(argv: string[], logger = console, cmd = "amplint") {
   // Options is argv with "curl" and all -H flags removed (to pass to
   // program.parse())
   const options = seq(0, argv.length - 1)
-    .filter(
-      (n) => argv[n] !== "curl" && argv[n] !== "-H" && argv[n - 1] !== "-H"
-    )
+    .filter((n) => argv[n] !== 'curl' && argv[n] !== '-H' && argv[n - 1] !== '-H')
     .map((n) => argv[n]);
 
   program.parse(options);
@@ -106,9 +95,9 @@ export function cli(argv: string[], logger = console, cmd = "amplint") {
   const customProgram = (program as unknown) as {
     userAgent: string;
     format: string;
-    force: LintMode | "auto";
+    force: LintMode | 'auto';
     url: string;
-    headers: { [k: string]: string };
+    headers: {[k: string]: string};
     showPassing: boolean;
     reportMode: boolean;
   };
@@ -142,38 +131,36 @@ export async function easyLint({
   url: string;
   userAgent: string;
   format: string;
-  force: LintMode | "auto";
-  headers: { [k: string]: string };
+  force: LintMode | 'auto';
+  headers: {[k: string]: string};
   showPassing: boolean;
   reportMode: boolean;
 }) {
-  headers["user-agent"] = UA[userAgent as keyof typeof UA];
+  headers['user-agent'] = UA[userAgent as keyof typeof UA];
 
   const raw = await (async () => {
-    if (url === "-") {
+    if (url === '-') {
       return Promise.resolve({
-        body: readFileSync("/dev/stdin").toString(),
+        body: readFileSync('/dev/stdin').toString(),
         headers: {},
       });
     }
-    const debug = fetchToCurl(url, { headers });
+    const debug = fetchToCurl(url, {headers});
     try {
-      const res = await fetch(url, { headers });
+      const res = await fetch(url, {headers});
       return res.ok
         ? Promise.resolve({
             headers: res.headers,
             body: await res.text(),
           })
-        : Promise.reject(
-            `couldn't load [${url}]: ${res.statusText} [debug: ${debug}]`
-          );
+        : Promise.reject(`couldn't load [${url}]: ${res.statusText} [debug: ${debug}]`);
     } catch (e) {
       return Promise.reject(`couldn't load [${url}] [debug: ${debug}]`);
     }
   })();
 
   const $ = cheerio.load(raw.body);
-  const mode = force === "auto" ? guessMode($) : force;
+  const mode = force === 'auto' ? guessMode($) : force;
   return printer(
     format,
     showPassing,
@@ -207,36 +194,36 @@ function printer(
   type: string,
   showPassing: boolean,
   reportMode: boolean,
-  data: { [key: string]: Result | Result[] }
+  data: {[key: string]: Result | Result[]}
 ): string {
-  function flatten(data: { [k: string]: Result | Result[] }): string[][] {
+  function flatten(data: {[k: string]: Result | Result[]}): string[][] {
     const rows: string[][] = [];
-    rows.push(["id", "title", "status", "message"]);
+    rows.push(['id', 'title', 'status', 'message']);
     for (const k of Object.keys(data).sort()) {
       const v = data[k];
       if (!isArray(v)) {
-        rows.push([k, v.title, v.status, v.message || ""]);
+        rows.push([k, v.title, v.status, v.message || '']);
       } else {
         for (const vv of v) {
-          rows.push([k, vv.title, vv.status, vv.message || ""]);
+          rows.push([k, vv.title, vv.status, vv.message || '']);
         }
       }
     }
     return rows;
   }
-  let sep = "\t";
+  let sep = '\t';
   switch (type) {
-    case "tsv":
+    case 'tsv':
       return flatten(data)
         .map((l) => l.join(sep))
-        .join("\n");
-    case "html":
+        .join('\n');
+    case 'html':
       const res = flatten(data).splice(1);
       const thead = `<tr><th>Name</th><th>Status</th><th>Message</th><tr>`;
       const tbody = res
-        .map((r) => r.map((td) => `<td>${escape(td)}</td>`).join(""))
+        .map((r) => r.map((td) => `<td>${escape(td)}</td>`).join(''))
         .map((r) => `<tr>${r}</tr>`)
-        .join("");
+        .join('');
       return [
         `<table class="amplint">`,
         `<thead>`,
@@ -246,10 +233,10 @@ function printer(
         tbody,
         `</tbody>`,
         `</table>`,
-      ].join("\n");
-    case "json":
+      ].join('\n');
+    case 'json':
       return JSON.stringify(data, null, 2);
-    case "text":
+    case 'text':
     default:
       return flatten(data)
         .splice(1)
@@ -264,16 +251,16 @@ function printer(
           // If PASS
           //  check whether to include in output w/ or w/o reporting
           //  or return empty
-          return l[3] !== "" && (l[2] as Status) !== Status.PASS
+          return l[3] !== '' && (l[2] as Status) !== Status.PASS
             ? `${colorStatus(l[2] as Status)} ${l[1]}\n> ${l[3]}\n`
-            : showPassing && reportMode && l[3] !== ""
+            : showPassing && reportMode && l[3] !== ''
             ? `${colorStatus(l[2] as Status)} ${l[1]}\n ${l[3]}\n`
             : showPassing
             ? `${colorStatus(l[2] as Status)} ${l[1]}\n`
-            : "";
+            : '';
         })
         .filter((line) => line.length > 0)
-        .join("\n");
+        .join('\n');
   }
 }
 

--- a/packages/linter/src/filter.ts
+++ b/packages/linter/src/filter.ts
@@ -1,5 +1,5 @@
-import { Response } from "node-fetch";
-import { Result, Status } from ".";
+import {Response} from 'node-fetch';
+import {Result, Status} from '.';
 
 export function isPass(m: Result): boolean {
   return m.status === Status.PASS;
@@ -14,11 +14,9 @@ export function isAccessControlHeaders(
   sourceOrigin: string
 ): (res: Response) => Promise<Response> {
   return (res) => {
-    const h1 = res.headers.get("access-control-allow-origin") || "";
-    if (h1 !== origin && h1 !== "*") {
-      throw new Error(
-        `access-control-allow-origin header is [${h1}], expected [${origin}]`
-      );
+    const h1 = res.headers.get('access-control-allow-origin') || '';
+    if (h1 !== origin && h1 !== '*') {
+      throw new Error(`access-control-allow-origin header is [${h1}], expected [${origin}]`);
     }
     // The AMP docs specify that the AMP-Access-Control-Allow-Source-Origin and
     // Access-Control-Expose-Headers headers must be returned, but this is not
@@ -44,15 +42,13 @@ export function isAccessControlHeaders(
 export async function isJson(res: Response): Promise<Response> {
   const contentType = (() => {
     if (!res.headers) {
-      return "";
+      return '';
     }
-    const s = res.headers.get("content-type") || "";
-    return s.toLowerCase().split(";")[0];
+    const s = res.headers.get('content-type') || '';
+    return s.toLowerCase().split(';')[0];
   })();
-  if (contentType !== "application/json") {
-    throw new Error(
-      `expected content-type: [application/json]; actual: [${contentType}]`
-    );
+  if (contentType !== 'application/json') {
+    throw new Error(`expected content-type: [application/json]; actual: [${contentType}]`);
   }
   const text = await res.text();
   try {
@@ -75,8 +71,6 @@ export function isStatusNotOk(res: Response) {
   if (!res.ok) {
     return Promise.resolve(res);
   } else {
-    throw new Error(
-      `expected status code: [1xx, 3xx, 4xx, 5xx], actual [${res.status}]`
-    );
+    throw new Error(`expected status code: [1xx, 3xx, 4xx, 5xx], actual [${res.status}]`);
   }
 }

--- a/packages/linter/src/global.d.ts
+++ b/packages/linter/src/global.d.ts
@@ -1,4 +1,4 @@
-declare module "probe-image-size" {
+declare module 'probe-image-size' {
   export interface ImageSize {
     width: number;
     height: number;
@@ -8,28 +8,25 @@ declare module "probe-image-size" {
 
   export default function probe(
     url: string | undefined,
-    args: { headers: { [k: string]: string } }
+    args: {headers: {[k: string]: string}}
   ): Promise<ImageSize>;
 }
 
-declare module "amphtml-validator" {
+declare module 'amphtml-validator' {
   export function getInstance(
     s?: string
   ): Promise<{
-    validateString: (s: string) => { status: string; errors: any[] };
+    validateString: (s: string) => {status: string; errors: any[]};
   }>;
 }
 
-declare module "@ampproject/toolbox-cache-url" {
-  export function createCacheUrl(
-    cacheSuffix: string,
-    url: string
-  ): Promise<string>;
+declare module '@ampproject/toolbox-cache-url' {
+  export function createCacheUrl(cacheSuffix: string, url: string): Promise<string>;
 }
 
-declare module "@ampproject/toolbox-cache-list" {
+declare module '@ampproject/toolbox-cache-list' {
   export default class Caches {
     constructor();
-    list(): Promise<Array<{ cacheDomain: string }>>;
+    list(): Promise<Array<{cacheDomain: string}>>;
   }
 }

--- a/packages/linter/src/index.ts
+++ b/packages/linter/src/index.ts
@@ -1,59 +1,59 @@
-import { cli } from "./cli";
-import { LinkRelCanonicalIsOk } from "./rules/LinkRelCanonicalIsOk";
-import { AmpVideoIsSmall } from "./rules/AmpVideoIsSmall";
-import { AmpVideoIsSpecifiedByAttribute } from "./rules/AmpVideoIsSpecifiedByAttribute";
-import { StoryRuntimeIsV1 } from "./rules/StoryRuntimeIsV1";
-import { StoryMetadataIsV1 } from "./rules/StoryMetadataIsV1";
-import { MetaCharsetIsFirst } from "./rules/MetaCharsetIsFirst";
-import { RuntimeIsPreloaded } from "./rules/RuntimeIsPreloaded";
-import { StoryIsMostlyText } from "./rules/StoryIsMostlyText";
-import { StoryMetadataThumbnailsAreOk } from "./rules/StoryMetadataThumbnailsAreOk";
-import { AmpImgHeightWidthIsOk } from "./rules/AmpImgHeightWidthIsOk";
-import { AmpImgAmpPixelPreferred } from "./rules/AmpImgAmpPixelPreferred";
-import { AmpImgPlaceholderIsDataUri } from "./rules/AmpImgPlaceholderIsDataUri";
-import { EndpointsAreAccessibleFromOrigin } from "./rules/EndpointsAreAccessibleFromOrigin";
-import { EndpointsAreAccessibleFromCache } from "./rules/EndpointsAreAccessibleFromCache";
-import { SxgVaryOnAcceptAct } from "./rules/SxgVaryOnAcceptAct";
-import { SxgContentNegotiationIsOk } from "./rules/SxgContentNegotiationIsOk";
-import { SxgDumpSignedExchangeVerify } from "./rules/SxgDumpSignedExchangeVerify";
-import { SxgAmppkgIsForwarded } from "./rules/SxgAmppkgIsForwarded";
-import { MetadataIncludesOGImageSrc } from "./rules/MetadataIncludesOGImageSrc";
-import { ImagesHaveAltText } from "./rules/ImagesHaveAltText";
-import { VideosHaveAltText } from "./rules/VideosHaveAltText";
-import { VideosAreSubtitled } from "./rules/VideosAreSubtitled";
-import { IsValid } from "./rules/IsValid";
-import { TitleMeetsLengthCriteria } from "./rules/TitleMeetsLengthCriteria";
-import { IsTransformedAmp } from "./rules/IsTransformedAmp";
-import { ModuleRuntimeUsed } from "./rules/ModuleRuntimeUsed";
-import { BlockingExtensionsPreloaded } from "./rules/BlockingExtensionsPreloaded";
-import { FontsArePreloaded } from "./rules/FontsArePreloaded";
-import { HeroImageIsDefined } from "./rules/HeroImageIsDefined";
-import { FastGoogleFontsDisplay } from "./rules/FastGoogleFontsDisplay";
-import { NoIconFontIsUsed } from "./rules/NoIconFontIsUsed";
-import { GoogleFontPreconnect } from "./rules/GoogleFontPreconnect";
-import { BoilerplateIsRemoved } from "./rules/BoilerplateIsRemoved";
-import { AmpImgUsesSrcSet } from "./rules/AmpImgUsesSrcSet";
-import { ViewportDisablesTapDelay } from "./rules/ViewportDisablesTapDelay";
-import { IsUsingLatestComponentVersion } from "./rules/IsUsingLatestComponentVersion";
-import { RuleConstructor } from "./rule";
-import { isArray } from "util";
-import * as cheerio from "cheerio";
+import {cli} from './cli';
+import {LinkRelCanonicalIsOk} from './rules/LinkRelCanonicalIsOk';
+import {AmpVideoIsSmall} from './rules/AmpVideoIsSmall';
+import {AmpVideoIsSpecifiedByAttribute} from './rules/AmpVideoIsSpecifiedByAttribute';
+import {StoryRuntimeIsV1} from './rules/StoryRuntimeIsV1';
+import {StoryMetadataIsV1} from './rules/StoryMetadataIsV1';
+import {MetaCharsetIsFirst} from './rules/MetaCharsetIsFirst';
+import {RuntimeIsPreloaded} from './rules/RuntimeIsPreloaded';
+import {StoryIsMostlyText} from './rules/StoryIsMostlyText';
+import {StoryMetadataThumbnailsAreOk} from './rules/StoryMetadataThumbnailsAreOk';
+import {AmpImgHeightWidthIsOk} from './rules/AmpImgHeightWidthIsOk';
+import {AmpImgAmpPixelPreferred} from './rules/AmpImgAmpPixelPreferred';
+import {AmpImgPlaceholderIsDataUri} from './rules/AmpImgPlaceholderIsDataUri';
+import {EndpointsAreAccessibleFromOrigin} from './rules/EndpointsAreAccessibleFromOrigin';
+import {EndpointsAreAccessibleFromCache} from './rules/EndpointsAreAccessibleFromCache';
+import {SxgVaryOnAcceptAct} from './rules/SxgVaryOnAcceptAct';
+import {SxgContentNegotiationIsOk} from './rules/SxgContentNegotiationIsOk';
+import {SxgDumpSignedExchangeVerify} from './rules/SxgDumpSignedExchangeVerify';
+import {SxgAmppkgIsForwarded} from './rules/SxgAmppkgIsForwarded';
+import {MetadataIncludesOGImageSrc} from './rules/MetadataIncludesOGImageSrc';
+import {ImagesHaveAltText} from './rules/ImagesHaveAltText';
+import {VideosHaveAltText} from './rules/VideosHaveAltText';
+import {VideosAreSubtitled} from './rules/VideosAreSubtitled';
+import {IsValid} from './rules/IsValid';
+import {TitleMeetsLengthCriteria} from './rules/TitleMeetsLengthCriteria';
+import {IsTransformedAmp} from './rules/IsTransformedAmp';
+import {ModuleRuntimeUsed} from './rules/ModuleRuntimeUsed';
+import {BlockingExtensionsPreloaded} from './rules/BlockingExtensionsPreloaded';
+import {FontsArePreloaded} from './rules/FontsArePreloaded';
+import {HeroImageIsDefined} from './rules/HeroImageIsDefined';
+import {FastGoogleFontsDisplay} from './rules/FastGoogleFontsDisplay';
+import {NoIconFontIsUsed} from './rules/NoIconFontIsUsed';
+import {GoogleFontPreconnect} from './rules/GoogleFontPreconnect';
+import {BoilerplateIsRemoved} from './rules/BoilerplateIsRemoved';
+import {AmpImgUsesSrcSet} from './rules/AmpImgUsesSrcSet';
+import {ViewportDisablesTapDelay} from './rules/ViewportDisablesTapDelay';
+import {IsUsingLatestComponentVersion} from './rules/IsUsingLatestComponentVersion';
+import {RuleConstructor} from './rule';
+import {isArray} from 'util';
+import * as cheerio from 'cheerio';
 
 export enum LintMode {
-  Amp = "amp",
-  AmpStory = "ampstory",
-  Amp4Ads = "amp4ads",
-  Amp4Email = "amp4email",
-  PageExperience = "pageexperience",
-  Sxg = "sxg",
+  Amp = 'amp',
+  AmpStory = 'ampstory',
+  Amp4Ads = 'amp4ads',
+  Amp4Email = 'amp4email',
+  PageExperience = 'pageexperience',
+  Sxg = 'sxg',
 }
 
 export enum Status {
-  PASS = "PASS",
-  FAIL = "FAIL",
-  WARN = "WARN",
-  INFO = "INFO",
-  INTERNAL_ERROR = "INTERNAL_ERROR",
+  PASS = 'PASS',
+  FAIL = 'FAIL',
+  WARN = 'WARN',
+  INFO = 'INFO',
+  INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
 
 export enum StatusNumber {
@@ -75,7 +75,7 @@ export interface Result {
 export interface Context {
   readonly url: string;
   readonly $: cheerio.Root;
-  readonly raw: { headers: { [key: string]: string }; body: string };
+  readonly raw: {headers: {[key: string]: string}; body: string};
   readonly headers: {
     [key: string]: string;
   };
@@ -83,16 +83,16 @@ export interface Context {
 }
 
 export interface Metadata {
-  "title"?: string;
-  "publisher"?: string;
-  "publisher-logo-src"?: string;
-  "poster-portrait-src"?: string;
-  "poster-square-src"?: string;
-  "poster-landscape-src"?: string;
+  'title'?: string;
+  'publisher'?: string;
+  'publisher-logo-src'?: string;
+  'poster-portrait-src'?: string;
+  'poster-square-src'?: string;
+  'poster-landscape-src'?: string;
 }
 
 export function guessMode($: cheerio.Root): LintMode {
-  if ($("body amp-story[standalone]").length === 1) {
+  if ($('body amp-story[standalone]').length === 1) {
     return LintMode.AmpStory;
   }
   // TODO Add tests for the other types
@@ -157,9 +157,7 @@ function testsForMode(type: LintMode) {
   return tests.get(type) || [];
 }
 
-export async function lint(
-  context: Context
-): Promise<{ [key: string]: Result | Result[] }> {
+export async function lint(context: Context): Promise<{[key: string]: Result | Result[]}> {
   const res = await Promise.all(
     testsForMode(context.mode).map(async (tc) => {
       const t = new tc();
@@ -172,7 +170,7 @@ export async function lint(
           // artificially create a "PASS".
           return [
             t.constructor.name,
-            [Object.assign({ status: Status.PASS, message: "" }, t.meta())],
+            [Object.assign({status: Status.PASS, message: ''}, t.meta())],
           ];
         } else {
           return [t.constructor.name, r];
@@ -188,16 +186,10 @@ export async function lint(
       }
     })
   );
-  return res.reduce(
-    (
-      a: { [key: string]: Result | Result[] },
-      kv: [string, Result | Result[]]
-    ) => {
-      a[kv[0].toLowerCase()] = kv[1];
-      return a;
-    },
-    {}
-  );
+  return res.reduce((a: {[key: string]: Result | Result[]}, kv: [string, Result | Result[]]) => {
+    a[kv[0].toLowerCase()] = kv[1];
+    return a;
+  }, {});
 }
 
-export { cli };
+export {cli};

--- a/packages/linter/src/rule.ts
+++ b/packages/linter/src/rule.ts
@@ -1,4 +1,4 @@
-import { Context, Result, Status } from "./index";
+import {Context, Result, Status} from './index';
 
 // Don't completely understand why we need to do this instead of "typeof Rule"
 // (should be equivalent??) but whatever. See
@@ -11,13 +11,13 @@ export abstract class Rule {
   abstract run(context: Context): Promise<Result | Array<Result>>;
   public meta() {
     return {
-      url: "",
+      url: '',
       title:
         this.constructor.name.replace(
           /([a-z])([A-Z])/g,
           (_, c1, c2) => `${c1} ${c2.toLowerCase()}`
-        ) + "?",
-      info: "",
+        ) + '?',
+      info: '',
     };
   }
   protected async pass(s?: string) {

--- a/packages/linter/src/rules/AmpImgAmpPixelPreferred.ts
+++ b/packages/linter/src/rules/AmpImgAmpPixelPreferred.ts
@@ -1,23 +1,21 @@
-import { Context, Result } from "../index";
-import { Rule } from "../rule";
-import { notPass } from "../filter";
+import {Context, Result} from '../index';
+import {Rule} from '../rule';
+import {notPass} from '../filter';
 
 export class AmpImgAmpPixelPreferred extends Rule {
   async run(context: Context) {
     const $ = context.$;
     return (
       await Promise.all(
-        $("amp-img[width=1][height=1]")
+        $('amp-img[width=1][height=1]')
           .map((_, e) => {
-            const layout = $(e).attr("layout");
-            if (layout === "responsive") {
+            const layout = $(e).attr('layout');
+            if (layout === 'responsive') {
               // see comment at AmpImgHeightWidthIsOk
               return this.pass();
             }
             const s = $(e).toString();
-            return this.warn(
-              `[${s}] has width=1, height=1; <amp-pixel> may be a better choice`
-            );
+            return this.warn(`[${s}] has width=1, height=1; <amp-pixel> may be a better choice`);
           })
           .get() as Array<Promise<Result>>
       )
@@ -25,9 +23,9 @@ export class AmpImgAmpPixelPreferred extends Rule {
   }
   meta() {
     return {
-      url: "",
-      title: "1x1 images are specified by <amp-pixel>",
-      info: "",
+      url: '',
+      title: '1x1 images are specified by <amp-pixel>',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/AmpImgHeightWidthIsOk.ts
+++ b/packages/linter/src/rules/AmpImgHeightWidthIsOk.ts
@@ -1,7 +1,7 @@
-import { absoluteUrl, dimensions } from "../helper";
-import { Context, Result } from "../index";
-import { Rule } from "../rule";
-import { notPass } from "../filter";
+import {absoluteUrl, dimensions} from '../helper';
+import {Context, Result} from '../index';
+import {Rule} from '../rule';
+import {notPass} from '../filter';
 
 export class AmpImgHeightWidthIsOk extends Rule {
   async run(context: Context) {
@@ -13,19 +13,11 @@ export class AmpImgHeightWidthIsOk extends Rule {
       expectedWidth: number,
       expectedHeight: number
     ): Promise<Result> => {
-      const success = ({
-        height,
-        width,
-      }: {
-        height: number;
-        width: number;
-      }): Promise<Result> => {
+      const success = ({height, width}: {height: number; width: number}): Promise<Result> => {
         const actualHeight = height;
         const actualWidth = width;
-        const actualRatio =
-          Math.floor((actualWidth * 100) / actualHeight) / 100;
-        const expectedRatio =
-          Math.floor((expectedWidth * 100) / expectedHeight) / 100;
+        const actualRatio = Math.floor((actualWidth * 100) / actualHeight) / 100;
+        const expectedRatio = Math.floor((expectedWidth * 100) / expectedHeight) / 100;
         if (Math.abs(actualRatio - expectedRatio) > 0.015) {
           const actualString = `${actualWidth}/${actualHeight} = ${actualRatio}`;
           const expectedString = `${expectedWidth}/${expectedHeight} = ${expectedRatio}`;
@@ -34,7 +26,7 @@ export class AmpImgHeightWidthIsOk extends Rule {
           );
         }
         // "For responsive images, the width and height do not need to match the exact width and height of the amp-img; those values just need to result in the same aspect-ratio." https://amp.dev/documentation/components/amp-img#the-difference-between-responsive-and-intrinsic-layout
-        if (layout.toLowerCase() === "responsive") {
+        if (layout.toLowerCase() === 'responsive') {
           return this.pass();
         }
         const actualVolume = actualWidth * actualHeight;
@@ -55,7 +47,7 @@ export class AmpImgHeightWidthIsOk extends Rule {
         }
         return this.pass();
       };
-      const fail = (e: { statusCode: number }) => {
+      const fail = (e: {statusCode: number}) => {
         if (e.statusCode === undefined) {
           return this.fail(`[${src}] ${JSON.stringify(e)}`);
         } else {
@@ -63,10 +55,7 @@ export class AmpImgHeightWidthIsOk extends Rule {
         }
       };
       try {
-        const result = await dimensions(
-          context,
-          absoluteUrl(src, context.url)!
-        );
+        const result = await dimensions(context, absoluteUrl(src, context.url)!);
         return success(result);
       } catch (e) {
         return fail(e);
@@ -74,18 +63,18 @@ export class AmpImgHeightWidthIsOk extends Rule {
     };
     return (
       await Promise.all(
-        ($("amp-img")
+        ($('amp-img')
           .filter(
             // filter out <amp-img> elements that are the first child of an
             // <amp-story-grid-layer template="fill"> (for these, height/width is
             // ignored).
-            (_, e) => !$(e).parent().is("amp-story-grid-layer[template=fill]")
+            (_, e) => !$(e).parent().is('amp-story-grid-layer[template=fill]')
           )
           .map((_, e) => {
-            const src = $(e).attr("src") || "";
-            const expectedHeight = parseInt($(e).attr("height") || "", 10);
-            const expectedWidth = parseInt($(e).attr("width") || "", 10);
-            const layout = $(e).attr("layout") || "";
+            const src = $(e).attr('src') || '';
+            const expectedHeight = parseInt($(e).attr('height') || '', 10);
+            const expectedWidth = parseInt($(e).attr('width') || '', 10);
+            const layout = $(e).attr('layout') || '';
             return test(src, layout, expectedWidth, expectedHeight);
           })
           .get() as unknown) as Array<Promise<Result>>
@@ -94,9 +83,9 @@ export class AmpImgHeightWidthIsOk extends Rule {
   }
   meta() {
     return {
-      url: "",
-      title: "All <amp-img> have reasonable width and height",
-      info: "",
+      url: '',
+      title: 'All <amp-img> have reasonable width and height',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/AmpImgPlaceholderIsDataUri.ts
+++ b/packages/linter/src/rules/AmpImgPlaceholderIsDataUri.ts
@@ -1,36 +1,37 @@
-import { Context, Result } from "../index";
-import { Rule } from "../rule";
-import { notPass } from '../filter';
+import {Context, Result} from '../index';
+import {Rule} from '../rule';
+import {notPass} from '../filter';
 
 export class AmpImgPlaceholderIsDataUri extends Rule {
   async run(context: Context) {
     const $ = context.$;
 
-    const incorrectImages = $("amp-img")
-      .filter((_, e) => {
-        const placeholders = $(e).children('amp-img[placeholder]');
-        const hasIncorrectPlaceholder = !!placeholders.toArray().find((placeholder) => 
-          !$(placeholder).attr("src").startsWith('data:')
-        );
-        return hasIncorrectPlaceholder;
-      });
+    const incorrectImages = $('amp-img').filter((_, e) => {
+      const placeholders = $(e).children('amp-img[placeholder]');
+      const hasIncorrectPlaceholder = !!placeholders
+        .toArray()
+        .find((placeholder) => !$(placeholder).attr('src').startsWith('data:'));
+      return hasIncorrectPlaceholder;
+    });
 
     return (
       await Promise.all(
-        incorrectImages.map((_, e) => {
-          const s = $(e).toString();
-          return this.warn(
-            `[${s}] has a placeholder that makes a network request. This hurts LCP, omit it or use a data URI.`
-          );
-        }).get() as Array<Promise<Result>>
+        incorrectImages
+          .map((_, e) => {
+            const s = $(e).toString();
+            return this.warn(
+              `[${s}] has a placeholder that makes a network request. This hurts LCP, omit it or use a data URI.`
+            );
+          })
+          .get() as Array<Promise<Result>>
       )
     ).filter(notPass);
   }
   meta() {
     return {
-      url: "",
-      title: "<amp-img> placeholder should not make a network request",
-      info: "",
+      url: '',
+      title: '<amp-img> placeholder should not make a network request',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/AmpImgUsesSrcSet.ts
+++ b/packages/linter/src/rules/AmpImgUsesSrcSet.ts
@@ -1,49 +1,47 @@
-import { Context, Result } from "../index";
-import { Rule } from "../rule";
-import { notPass } from '../filter';
+import {Context, Result} from '../index';
+import {Rule} from '../rule';
+import {notPass} from '../filter';
 
-const CHECKED_IMG_LAYOUTS = ["fill", "flex-item", "intrinsic", "responsive"];
+const CHECKED_IMG_LAYOUTS = ['fill', 'flex-item', 'intrinsic', 'responsive'];
 
-const SVG_URL_PATTERN = /^[^?]+\.svg(\?.*)?$/i
+const SVG_URL_PATTERN = /^[^?]+\.svg(\?.*)?$/i;
 
 export class AmpImgUsesSrcSet extends Rule {
   async run(context: Context) {
     const $ = context.$;
 
-    const incorrectImages = $("amp-img")
-        .filter((_, e) => {
-          const src = $(e).attr("src");
-          let layout = $(e).attr("layout");
-          const srcset = $(e).attr("srcset");
-          const parent = $(e).parent();
-          if (parent.prop("tagName").startsWith('AMP-')) {
-            const parentLayout = $(parent).attr("layout");
-            if (parentLayout) {
-              layout = parentLayout;
-            }
-          }
-          return (
-            !SVG_URL_PATTERN.exec(src)
-            && layout && CHECKED_IMG_LAYOUTS.includes(layout)
-            && !srcset
-          )
-        });
+    const incorrectImages = $('amp-img').filter((_, e) => {
+      const src = $(e).attr('src');
+      let layout = $(e).attr('layout');
+      const srcset = $(e).attr('srcset');
+      const parent = $(e).parent();
+      if (parent.prop('tagName').startsWith('AMP-')) {
+        const parentLayout = $(parent).attr('layout');
+        if (parentLayout) {
+          layout = parentLayout;
+        }
+      }
+      return (
+        !SVG_URL_PATTERN.exec(src) && layout && CHECKED_IMG_LAYOUTS.includes(layout) && !srcset
+      );
+    });
     return (
       await Promise.all(
-        incorrectImages.map((_, e) => {
-          const s = $(e).toString();
-          return this.warn(
-            `[${s}] should define a srcset. Using AMP Optimizer might help.`
-          );
-        }).get() as Array<Promise<Result>>
+        incorrectImages
+          .map((_, e) => {
+            const s = $(e).toString();
+            return this.warn(`[${s}] should define a srcset. Using AMP Optimizer might help.`);
+          })
+          .get() as Array<Promise<Result>>
       )
     ).filter(notPass);
   }
   meta() {
     return {
-      url: "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/explainer/?format=websites#image-optimization",
-      title: "<amp-img> with non-fixed layout uses srcset",
-      info: "",
+      url:
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/explainer/?format=websites#image-optimization',
+      title: '<amp-img> with non-fixed layout uses srcset',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/AmpVideoIsSmall.ts
+++ b/packages/linter/src/rules/AmpVideoIsSmall.ts
@@ -1,20 +1,20 @@
-import { absoluteUrl, contentLength } from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {absoluteUrl, contentLength} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class AmpVideoIsSmall extends Rule {
   async run(context: Context) {
-    const { $ } = context;
+    const {$} = context;
     const args = await Promise.all(
       ($(`amp-video source[type="video/mp4"][src], amp-video[src]`)
         .map(async (i, e) => {
-          const url = absoluteUrl($(e).attr("src"), context.url);
+          const url = absoluteUrl($(e).attr('src'), context.url);
           try {
             const length = await contentLength(context, url!);
-            return { url, length };
+            return {url, length};
           } catch (e) {
             // URL is non-2xx (TODO: improve error handling)
-            return { url, length: -1 };
+            return {url, length: -1};
           }
         })
         .get() as unknown) as Array<
@@ -39,17 +39,17 @@ export class AmpVideoIsSmall extends Rule {
     // Over 4MB is too big: https://amp.dev/documentation/guides-and-tutorials/develop/amp_story_best_practices#size/length-of-video
     const large = Object.keys(videos).filter((v) => videos[v] > 4000000);
     if (large.length > 0) {
-      return this.fail(`videos over 4MB: [${large.join(",")}]`);
+      return this.fail(`videos over 4MB: [${large.join(',')}]`);
     } else {
-      return this.pass(`[${Object.keys(videos).join(",")}] are all under 4MB`);
+      return this.pass(`[${Object.keys(videos).join(',')}] are all under 4MB`);
     }
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/develop/amp_story_best_practices#size/length-of-video",
-      title: "Videos are under 4MB",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/develop/amp_story_best_practices#size/length-of-video',
+      title: 'Videos are under 4MB',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/AmpVideoIsSpecifiedByAttribute.ts
+++ b/packages/linter/src/rules/AmpVideoIsSpecifiedByAttribute.ts
@@ -1,21 +1,19 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class AmpVideoIsSpecifiedByAttribute extends Rule {
-  run({ $ }: Context) {
-    if ($("amp-video[src]").length > 0) {
-      return this.warn(
-        "<amp-video src> used instead of <amp-video><source/></amp-video>"
-      );
+  run({$}: Context) {
+    if ($('amp-video[src]').length > 0) {
+      return this.warn('<amp-video src> used instead of <amp-video><source/></amp-video>');
     } else {
       return this.pass();
     }
   }
   meta() {
     return {
-      url: "",
-      title: "<amp-video><source/></amp-video> syntax is used for video",
-      info: "",
+      url: '',
+      title: '<amp-video><source/></amp-video> syntax is used for video',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/BlockingExtensionsPreloaded.ts
+++ b/packages/linter/src/rules/BlockingExtensionsPreloaded.ts
@@ -1,14 +1,10 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
-const blockingExtension = [
-  "amp-dynamic-css-classes",
-  "amp-experiment",
-  "amp-story",
-];
+const blockingExtension = ['amp-dynamic-css-classes', 'amp-experiment', 'amp-story'];
 
 export class BlockingExtensionsPreloaded extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     const results = [];
     blockingExtension.forEach((extension) => {
       const scriptPart = `/v0/${extension}-`;
@@ -23,9 +19,9 @@ export class BlockingExtensionsPreloaded extends Rule {
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading",
-      title: "Render-blocking extensions are preloaded",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading',
+      title: 'Render-blocking extensions are preloaded',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/BoilerplateIsRemoved.ts
+++ b/packages/linter/src/rules/BoilerplateIsRemoved.ts
@@ -1,17 +1,17 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import { isTransformedAmp } from "../helper";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import {isTransformedAmp} from '../helper';
 
 /**
  * Check if the AMP Optimizer removed the AMP Boilerplate.
  */
 export class BoilerplateIsRemoved extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     if (!isTransformedAmp($)) {
       // this check is only relevant for transformed amp pages
       return this.pass();
     }
-    const boilerplate = $("html[i-amphtml-no-boilerplate]");
+    const boilerplate = $('html[i-amphtml-no-boilerplate]');
     if (boilerplate.length > 0) {
       // The desired result: boilerplate is removed
       return this.pass();
@@ -28,19 +28,19 @@ export class BoilerplateIsRemoved extends Rule {
     );
     if (optionalBlockingElements.length > 0) {
       return this.info(
-        "Avoid amp-experiment and amp-dynamic-css-styles if possible to allow AMP Boilerplate removal"
+        'Avoid amp-experiment and amp-dynamic-css-styles if possible to allow AMP Boilerplate removal'
       );
     }
     return this.warn(
-      "AMP Boilerplate not removed. Please upgrade to the latest AMP Optimizer version"
+      'AMP Boilerplate not removed. Please upgrade to the latest AMP Optimizer version'
     );
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/",
-      title: "AMP Boilerplate is removed",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/',
+      title: 'AMP Boilerplate is removed',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/BookendExists.ts
+++ b/packages/linter/src/rules/BookendExists.ts
@@ -1,22 +1,19 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class BookendExists extends Rule {
   run(context: Context) {
-    const { $ } = context;
-    const s1 = $("amp-story amp-story-bookend").length === 1;
-    const s2 = $("amp-story").attr("bookend-config-src");
+    const {$} = context;
+    const s1 = $('amp-story amp-story-bookend').length === 1;
+    const s2 = $('amp-story').attr('bookend-config-src');
     const bookendSrc = s1 || s2;
-    return bookendSrc
-      ? this.pass()
-      : this.warn("<amp-story-bookend> not found");
+    return bookendSrc ? this.pass() : this.warn('<amp-story-bookend> not found');
   }
   meta() {
     return {
-      url:
-        "https://amp.dev/documentation/components/amp-story/#bookend:-amp-story-bookend",
-      title: "A bookend exists",
-      info: "",
+      url: 'https://amp.dev/documentation/components/amp-story/#bookend:-amp-story-bookend',
+      title: 'A bookend exists',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/EndpointsAreAccessibleFromCache.ts
+++ b/packages/linter/src/rules/EndpointsAreAccessibleFromCache.ts
@@ -1,27 +1,25 @@
-import { parse } from "url";
+import {parse} from 'url';
 
-import { createCacheUrl } from "@ampproject/toolbox-cache-url";
-import fetch from "node-fetch";
+import {createCacheUrl} from '@ampproject/toolbox-cache-url';
+import fetch from 'node-fetch';
 
-import { caches } from "../caches";
+import {caches} from '../caches';
 import {
   corsEndpoints,
   buildSourceOrigin,
   addSourceOrigin,
   fetchToCurl,
   absoluteUrl,
-} from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
-import { isStatusOk, isAccessControlHeaders, isJson, notPass } from "../filter";
+} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
+import {isStatusOk, isAccessControlHeaders, isJson, notPass} from '../filter';
 
 export class EndpointsAreAccessibleFromCache extends Rule {
   async run(context: Context) {
     // Cartesian product from https://stackoverflow.com/a/43053803/11543
     const cartesian = (a: any[], b: any[]) =>
-      ([] as any[]).concat(
-        ...a.map((d: any) => b.map((e: any) => ([] as any[]).concat(d, e)))
-      );
+      ([] as any[]).concat(...a.map((d: any) => b.map((e: any) => ([] as any[]).concat(d, e))));
     const e = corsEndpoints(context.$);
     const product = cartesian(
       e,
@@ -33,26 +31,25 @@ export class EndpointsAreAccessibleFromCache extends Rule {
       const obj = parse(url);
       const origin = `${obj.protocol}//${obj.host}`;
 
-      const headers = Object.assign({}, { origin }, context.headers);
+      const headers = Object.assign({}, {origin}, context.headers);
 
       const curl = fetchToCurl(addSourceOrigin(xhrUrl, sourceOrigin), {
         headers,
       });
 
-      return fetch(addSourceOrigin(xhrUrl, sourceOrigin), { headers })
+      return fetch(addSourceOrigin(xhrUrl, sourceOrigin), {headers})
         .then(isStatusOk)
         .then(isAccessControlHeaders(origin, sourceOrigin))
         .then(isJson)
         .then(
           () => this.pass(`${xhrUrl} is accessible from ${cacheSuffix}`),
-          (e) =>
-            this.fail(`can't XHR [${xhrUrl}]: ${e.message} [debug: ${curl}]`)
+          (e) => this.fail(`can't XHR [${xhrUrl}]: ${e.message} [debug: ${curl}]`)
         );
     };
     return (
       await Promise.all(
         product.map(([xhrUrl, cacheSuffix]) =>
-          canXhrCache(absoluteUrl(xhrUrl, context.url) || "", cacheSuffix)
+          canXhrCache(absoluteUrl(xhrUrl, context.url) || '', cacheSuffix)
         )
       )
     ).filter(notPass);
@@ -60,9 +57,9 @@ export class EndpointsAreAccessibleFromCache extends Rule {
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests/",
-      title: "Endpoints are accessible from cache",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests/',
+      title: 'Endpoints are accessible from cache',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/EndpointsAreAccessibleFromOrigin.ts
+++ b/packages/linter/src/rules/EndpointsAreAccessibleFromOrigin.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import fetch from 'node-fetch';
 
 import {
   corsEndpoints,
@@ -6,10 +6,10 @@ import {
   addSourceOrigin,
   absoluteUrl,
   fetchToCurl,
-} from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
-import { isStatusOk, isJson, notPass } from "../filter";
+} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
+import {isStatusOk, isJson, notPass} from '../filter';
 
 export class EndpointsAreAccessibleFromOrigin extends Rule {
   async run(context: Context) {
@@ -18,38 +18,32 @@ export class EndpointsAreAccessibleFromOrigin extends Rule {
       xhrUrl = absoluteUrl(xhrUrl, context.url)!;
       const sourceOrigin = buildSourceOrigin(context.url);
 
-      const headers = Object.assign(
-        { "amp-same-origin": "true" },
-        context.headers
-      );
+      const headers = Object.assign({'amp-same-origin': 'true'}, context.headers);
 
       const debug = fetchToCurl(addSourceOrigin(xhrUrl, sourceOrigin), {
         headers,
       });
 
-      return fetch(addSourceOrigin(xhrUrl, sourceOrigin), { headers })
+      return fetch(addSourceOrigin(xhrUrl, sourceOrigin), {headers})
         .then(isStatusOk)
         .then(isJson)
         .then(
           () => this.pass(`${xhrUrl} is accessible from ${sourceOrigin}`),
-          (e) =>
-            this.fail(`can't XHR [${xhrUrl}]: ${e.message} [debug: ${debug}]`)
+          (e) => this.fail(`can't XHR [${xhrUrl}]: ${e.message} [debug: ${debug}]`)
         );
     };
     return (
       await Promise.all(
-        e.map((url) =>
-          canXhrSameOrigin(absoluteUrl(url.toString(), context.url) || "")
-        )
+        e.map((url) => canXhrSameOrigin(absoluteUrl(url.toString(), context.url) || ''))
       )
     ).filter(notPass);
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests/",
-      title: "Endpoints are accessible from origin",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests/',
+      title: 'Endpoints are accessible from origin',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/FastGoogleFontsDisplay.ts
+++ b/packages/linter/src/rules/FastGoogleFontsDisplay.ts
@@ -1,5 +1,5 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 const GOOGLE_FONT_URL_PATTERN = /https?:\/\/fonts.googleapis.com\/css\?(?!(?:[\s\S]+&)?display=(?:swap|fallback|optional)(?:&|$))/i;
 
@@ -8,22 +8,18 @@ const GOOGLE_FONT_URL_PATTERN = /https?:\/\/fonts.googleapis.com\/css\?(?!(?:[\s
  * value of 'swap', 'fallback', or 'optional'
  */
 export class FastGoogleFontsDisplay extends Rule {
-  run({ $ }: Context) {
-    const fonts = $(
-      "link[rel='stylesheet'][href^='https://fonts.googleapis.com/css']"
-    );
+  run({$}: Context) {
+    const fonts = $("link[rel='stylesheet'][href^='https://fonts.googleapis.com/css']");
     if (!fonts.length) {
       return this.pass();
     }
     const results = [];
     fonts.each((i, linkNode) => {
-      const href = $(linkNode).attr("href");
+      const href = $(linkNode).attr('href');
       const match = GOOGLE_FONT_URL_PATTERN.exec(href);
       if (match) {
         results.push(
-          this.warn(
-            `Use &display=swap|fallback|optional in Google Font stylesheet URL: ${href}`
-          )
+          this.warn(`Use &display=swap|fallback|optional in Google Font stylesheet URL: ${href}`)
         );
       }
     });
@@ -31,9 +27,9 @@ export class FastGoogleFontsDisplay extends Rule {
   }
   meta() {
     return {
-      url: "https://web.dev/font-display/",
-      title: "Use fast font-display for Google Fonts",
-      info: "",
+      url: 'https://web.dev/font-display/',
+      title: 'Use fast font-display for Google Fonts',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/FontsArePreloaded.ts
+++ b/packages/linter/src/rules/FontsArePreloaded.ts
@@ -1,5 +1,5 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 const FONT_FACE_URL_PATTERN = /@font-face\s*\{(?![^}]*font-display)[^}]*\burl\s*\(/i;
 
@@ -9,24 +9,24 @@ const FONT_FACE_URL_PATTERN = /@font-face\s*\{(?![^}]*font-display)[^}]*\burl\s*
  * Font definitions with url but an additional font-display setting are ignored.
  */
 export class FontsArePreloaded extends Rule {
-  run({ $ }: Context) {
-    const css = $("style[amp-custom]").html();
+  run({$}: Context) {
+    const css = $('style[amp-custom]').html();
     if (!css || !FONT_FACE_URL_PATTERN.test(css)) {
       return this.pass();
     }
     const preloadedFonts = $("link[rel='preload'],[as='font']").length;
     if (preloadedFonts === 0) {
       return this.info(
-        "Web fonts are used without preloading. Preload them if they are used in the first viewport."
+        'Web fonts are used without preloading. Preload them if they are used in the first viewport.'
       );
     }
     return this.pass();
   }
   meta() {
     return {
-      url: "https://web.dev/codelab-preload-web-fonts/",
-      title: "Web fonts are preloaded",
-      info: "",
+      url: 'https://web.dev/codelab-preload-web-fonts/',
+      title: 'Web fonts are preloaded',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/GoogleFontPreconnect.ts
+++ b/packages/linter/src/rules/GoogleFontPreconnect.ts
@@ -1,24 +1,18 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 /**
  * This rule tests if the page contains a dns-prefetch and preconnect for
  * fonts.gstatic.com when Google Fonts are used.
  */
 export class GoogleFontPreconnect extends Rule {
-  run({ $ }: Context) {
-    const fonts = $(
-      "link[rel='stylesheet'][href^='https://fonts.googleapis.com/css']"
-    );
+  run({$}: Context) {
+    const fonts = $("link[rel='stylesheet'][href^='https://fonts.googleapis.com/css']");
     if (!fonts.length) {
       return this.pass();
     }
-    const preconnect = $(
-      "link[href*='//fonts.gstatic.com'][rel~='preconnect'][crossorigin]"
-    );
-    const dnsPrefetch = $(
-      "link[href*='//fonts.gstatic.com'][rel~='dns-prefetch']"
-    );
+    const preconnect = $("link[href*='//fonts.gstatic.com'][rel~='preconnect'][crossorigin]");
+    const dnsPrefetch = $("link[href*='//fonts.gstatic.com'][rel~='dns-prefetch']");
     if (!preconnect.length || !dnsPrefetch.length) {
       return this.warn(
         `Preconnect Google Fonts using <link href=https://fonts.gstatic.com rel="dns-prefetch preconnect" crossorigin>`
@@ -29,9 +23,9 @@ export class GoogleFontPreconnect extends Rule {
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading",
-      title: "Preconnecting Google Fonts",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading',
+      title: 'Preconnecting Google Fonts',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/HeroImageIsDefined.ts
+++ b/packages/linter/src/rules/HeroImageIsDefined.ts
@@ -1,6 +1,6 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import PreloadHeroImage from "@ampproject/toolbox-optimizer/lib/transformers/PreloadHeroImage";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import PreloadHeroImage from '@ampproject/toolbox-optimizer/lib/transformers/PreloadHeroImage';
 
 /**
  * This rule checks if the document contains possible hero elements
@@ -9,10 +9,9 @@ import PreloadHeroImage from "@ampproject/toolbox-optimizer/lib/transformers/Pre
  * and a relevant size.
  */
 export class HeroImageIsDefined extends Rule {
-  run({ $ }: Context) {
-    const hasHeroImage =
-      $("amp-img[data-hero],amp-iframe[data-hero]").length > 0;
-    const body = $("body");
+  run({$}: Context) {
+    const hasHeroImage = $('amp-img[data-hero],amp-iframe[data-hero]').length > 0;
+    const body = $('body');
     if (hasHeroImage || body.length === 0) {
       return this.pass();
     }
@@ -22,16 +21,16 @@ export class HeroImageIsDefined extends Rule {
     if (heroCandidates.find((heroImage) => heroImage.ampImg)) {
       // The PreloadHeroImage transformer will also return amp-video posters
       // but they cannot be marked as 'data-hero' and will not have the 'ampImg'
-      return this.warn("Use data-hero to mark hero images");
+      return this.warn('Use data-hero to mark hero images');
     }
     return this.pass();
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/explainer/?format=websites#hero-image-optimization",
-      title: "Hero image is defined",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/explainer/?format=websites#hero-image-optimization',
+      title: 'Hero image is defined',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/ImagesHaveAltText.ts
+++ b/packages/linter/src/rules/ImagesHaveAltText.ts
@@ -1,19 +1,19 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import chalk from "chalk";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import chalk from 'chalk';
 
 export class ImagesHaveAltText extends Rule {
-  run({ $ }: Context) {
-    let imgsWithoutAlt: { [key: string]: number } = {};
-    let output = "";
+  run({$}: Context) {
+    let imgsWithoutAlt: {[key: string]: number} = {};
+    let output = '';
 
     const color = (s: string) => {
       return chalk.yellow(s);
     };
 
-    $("amp-img").each(function (_, elem: cheerio.TagElement) {
+    $('amp-img').each(function (_, elem: cheerio.TagElement) {
       if (!elem.attribs.alt) {
-        if (typeof imgsWithoutAlt[elem.attribs.src] == "undefined") {
+        if (typeof imgsWithoutAlt[elem.attribs.src] == 'undefined') {
           imgsWithoutAlt[elem.attribs.src] = 1;
         } else {
           imgsWithoutAlt[elem.attribs.src] += 1;
@@ -23,19 +23,19 @@ export class ImagesHaveAltText extends Rule {
 
     for (let key in imgsWithoutAlt) {
       imgsWithoutAlt[key] > 1
-        ? (output += key + " [used " + imgsWithoutAlt[key] + " times]\n")
-        : (output += key + "\n");
+        ? (output += key + ' [used ' + imgsWithoutAlt[key] + ' times]\n')
+        : (output += key + '\n');
     }
 
     return Object.keys(imgsWithoutAlt).length > 0
-      ? this.warn("Missing alt text from images: \n" + output)
+      ? this.warn('Missing alt text from images: \n' + output)
       : this.pass();
   }
   meta() {
     return {
-      url: "https://blog.amp.dev/2020/02/12/seo-for-amp-stories/",
-      title: "Images contain alt text",
-      info: "",
+      url: 'https://blog.amp.dev/2020/02/12/seo-for-amp-stories/',
+      title: 'Images contain alt text',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/IsTransformedAmp.ts
+++ b/packages/linter/src/rules/IsTransformedAmp.ts
@@ -1,19 +1,17 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import { isTransformedAmp } from "../helper";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import {isTransformedAmp} from '../helper';
 
 export class IsTransformedAmp extends Rule {
-  run({ $ }: Context) {
-    return isTransformedAmp($)
-      ? this.pass()
-      : this.warn("No transformed AMP found");
+  run({$}: Context) {
+    return isTransformedAmp($) ? this.pass() : this.warn('No transformed AMP found');
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/",
-      title: "Page is transformed AMP",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/',
+      title: 'Page is transformed AMP',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/IsUsingLatestComponentVersion.ts
+++ b/packages/linter/src/rules/IsUsingLatestComponentVersion.ts
@@ -1,14 +1,14 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import validatorRules from "@ampproject/toolbox-validator-rules";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import validatorRules from '@ampproject/toolbox-validator-rules';
 
 const COMPONENT_SRC_MATCHER = /\/v0\/([^.]+)-(\d+(?:\.\d+)*)\.m?js/;
 
 export class IsUsingLatestComponentVersion extends Rule {
-  async run({ $ }: Context) {
+  async run({$}: Context) {
     const versionMap = {};
-    $("script[src]").each((i, script) => {
-      const match = COMPONENT_SRC_MATCHER.exec($(script).attr("src"));
+    $('script[src]').each((i, script) => {
+      const match = COMPONENT_SRC_MATCHER.exec($(script).attr('src'));
       if (match) {
         versionMap[match[1]] = match[2];
       }
@@ -17,27 +17,25 @@ export class IsUsingLatestComponentVersion extends Rule {
     const rules = await validatorRules.fetch();
     const componentVersions = {};
     rules.extensions.forEach((e) => {
-      const versions = e.version.filter((v) => v !== "latest");
-      if (e.htmlFormat.some((h) => h === "AMP")) {
+      const versions = e.version.filter((v) => v !== 'latest');
+      if (e.htmlFormat.some((h) => h === 'AMP')) {
         componentVersions[e.name] = versions[versions.length - 1];
       }
     });
 
-    const isUsingLatestComponentVersion = Object.entries(versionMap).filter(
-      ([name, version]) => {
-        return componentVersions[name] !== version;
-      }
-    );
+    const isUsingLatestComponentVersion = Object.entries(versionMap).filter(([name, version]) => {
+      return componentVersions[name] !== version;
+    });
 
     return isUsingLatestComponentVersion.length === 0
       ? this.pass()
-      : this.warn("Use the latest version of components");
+      : this.warn('Use the latest version of components');
   }
   meta() {
     return {
-      url: "",
-      title: "Outdated components are used",
-      info: "",
+      url: '',
+      title: 'Outdated components are used',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/IsValid.ts
+++ b/packages/linter/src/rules/IsValid.ts
@@ -1,19 +1,17 @@
-import { validate } from "../validate";
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {validate} from '../validate';
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class IsValid extends Rule {
-  async run({ raw }: Context) {
+  async run({raw}: Context) {
     const res = await validate(raw.body);
-    return res.status === "PASS"
-      ? this.pass()
-      : this.fail(JSON.stringify(res.errors));
+    return res.status === 'PASS' ? this.pass() : this.fail(JSON.stringify(res.errors));
   }
   meta() {
     return {
-      url: "https://validator.amp.dev/",
-      title: "Document is valid AMP",
-      info: "",
+      url: 'https://validator.amp.dev/',
+      title: 'Document is valid AMP',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/LinkRelCanonicalIsOk.ts
+++ b/packages/linter/src/rules/LinkRelCanonicalIsOk.ts
@@ -1,16 +1,16 @@
-import { absoluteUrl, redirectUrl } from "../helper";
-import { Context, LintMode } from "../index";
-import { Rule } from "../rule";
+import {absoluteUrl, redirectUrl} from '../helper';
+import {Context, LintMode} from '../index';
+import {Rule} from '../rule';
 
 export class LinkRelCanonicalIsOk extends Rule {
   async run(context: Context) {
-    const { $, url, mode } = context;
+    const {$, url, mode} = context;
     if (mode !== LintMode.AmpStory) {
       return this.pass();
     }
-    const canonical = $('link[rel="canonical"]').attr("href");
+    const canonical = $('link[rel="canonical"]').attr('href');
     if (!canonical) {
-      return this.fail("<link rel=canonical> not specified");
+      return this.fail('<link rel=canonical> not specified');
     }
     const s1 = absoluteUrl(canonical, url);
     // does canonical match url?
@@ -32,9 +32,9 @@ export class LinkRelCanonicalIsOk extends Rule {
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery/#what-if-i-only-have-one-page?",
-      title: "Story is self-canonical",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery/#what-if-i-only-have-one-page?',
+      title: 'Story is self-canonical',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/MetaCharsetIsFirst.ts
+++ b/packages/linter/src/rules/MetaCharsetIsFirst.ts
@@ -1,20 +1,17 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class MetaCharsetIsFirst extends Rule {
-  run({ $ }: Context) {
-    const firstChild = $("head *:first-child");
-    const charset = firstChild.attr("charset");
-    return !charset
-      ? this.fail(`<meta charset> not the first <meta> tag`)
-      : this.pass();
+  run({$}: Context) {
+    const firstChild = $('head *:first-child');
+    const charset = firstChild.attr('charset');
+    return !charset ? this.fail(`<meta charset> not the first <meta> tag`) : this.pass();
   }
   meta() {
     return {
-      url:
-        "https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding",
-      title: "<meta charset> is the first <meta> tag",
-      info: "",
+      url: 'https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding',
+      title: '<meta charset> is the first <meta> tag',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/MetadataIncludesOGImageSrc.ts
+++ b/packages/linter/src/rules/MetadataIncludesOGImageSrc.ts
@@ -1,33 +1,29 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class MetadataIncludesOGImageSrc extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     let hasOGImage = false;
 
-    $("meta").each(function (i, elem: cheerio.TagElement) {
+    $('meta').each(function (i, elem: cheerio.TagElement) {
       if (
         (elem.attribs.property &&
-          elem.attribs.property.includes("og:image", 0) &&
+          elem.attribs.property.includes('og:image', 0) &&
           elem.attribs.content) ||
-        (elem.attribs.name &&
-          elem.attribs.name.includes("og:image", 0) &&
-          elem.attribs.content)
+        (elem.attribs.name && elem.attribs.name.includes('og:image', 0) && elem.attribs.content)
       ) {
         hasOGImage = true;
         return false;
       }
     });
 
-    return !hasOGImage
-      ? this.warn(`Missing og:image property or content source`)
-      : this.pass();
+    return !hasOGImage ? this.warn(`Missing og:image property or content source`) : this.pass();
   }
   meta() {
     return {
-      url: "https://blog.amp.dev/2020/02/12/seo-for-amp-stories/",
-      title: "Metadata includes og:image and src",
-      info: "",
+      url: 'https://blog.amp.dev/2020/02/12/seo-for-amp-stories/',
+      title: 'Metadata includes og:image and src',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/ModuleRuntimeUsed.ts
+++ b/packages/linter/src/rules/ModuleRuntimeUsed.ts
@@ -1,26 +1,23 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import { isTransformedAmp } from "../helper";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import {isTransformedAmp} from '../helper';
 
 export class ModuleRuntimeUsed extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     if (!isTransformedAmp($)) {
       return this.pass();
     }
-    const isModuleVersion =
-      $("script[type='module'][src$='/v0.mjs']").length > 0;
+    const isModuleVersion = $("script[type='module'][src$='/v0.mjs']").length > 0;
     return isModuleVersion
       ? this.pass()
-      : this.warn(
-          "The JavaScript module version of the AMP Runtime is not used"
-        );
+      : this.warn('The JavaScript module version of the AMP Runtime is not used');
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/",
-      title: "Page is using JavaScript Module version of the AMP Runtime",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-optimizer-guide/',
+      title: 'Page is using JavaScript Module version of the AMP Runtime',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/NoIconFontIsUsed.ts
+++ b/packages/linter/src/rules/NoIconFontIsUsed.ts
@@ -1,65 +1,50 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
-const postcss = require("postcss");
-const safeParser = require("postcss-safe-parser");
+const postcss = require('postcss');
+const safeParser = require('postcss-safe-parser');
 
 const ICON_FONT_IDENTIFIERS = {
-  classNames: [
-    "fa-",
-    "nf-",
-    "material-icons",
-    "icofont-",
-    "icn-",
-    "icon-",
-    "icn",
-    "icon",
-  ],
+  classNames: ['fa-', 'nf-', 'material-icons', 'icofont-', 'icn-', 'icon-', 'icn', 'icon'],
   fontFamilies: [
-    "FontAwesome",
-    "Font Awesome",
-    "NerdFontsSymbols",
-    "Nerd Font",
-    "Material Icons",
-    "IcoFont",
-    "icon",
-    "icons",
-    "icomoon",
+    'FontAwesome',
+    'Font Awesome',
+    'NerdFontsSymbols',
+    'Nerd Font',
+    'Material Icons',
+    'IcoFont',
+    'icon',
+    'icons',
+    'icomoon',
   ],
-  urls: ["https://fonts.googleapis.com/icon?family=Material+Icons"],
+  urls: ['https://fonts.googleapis.com/icon?family=Material+Icons'],
 };
 
 /**
  * Checks if icon fonts are being used
  */
 export class NoIconFontIsUsed extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     // check for known classnames
-    const iconFontCandidates = ICON_FONT_IDENTIFIERS.classNames.filter(
-      (className) => {
-        return $(`[class*=${className} i]`).length > 0;
-      }
-    );
+    const iconFontCandidates = ICON_FONT_IDENTIFIERS.classNames.filter((className) => {
+      return $(`[class*=${className} i]`).length > 0;
+    });
 
     if (iconFontCandidates.length === 0) {
       return this.pass();
     }
 
     // check for known external stylesheets
-    const knownExternalStylesheets = ICON_FONT_IDENTIFIERS.urls.filter(
-      (url) => {
-        return $(`link[rel='stylesheet'][href^='${url}']`).length > 0;
-      }
-    );
+    const knownExternalStylesheets = ICON_FONT_IDENTIFIERS.urls.filter((url) => {
+      return $(`link[rel='stylesheet'][href^='${url}']`).length > 0;
+    });
 
     if (knownExternalStylesheets.length) {
-      return this.warn(
-        "Avoid using icon fonts to improve loading speed and accessibility"
-      );
+      return this.warn('Avoid using icon fonts to improve loading speed and accessibility');
     }
 
     // check for known font-families in documents custom styles
-    const stylesText = $("style[amp-custom]").html();
+    const stylesText = $('style[amp-custom]').html();
 
     if (!stylesText) {
       return this.pass();
@@ -78,12 +63,12 @@ export class NoIconFontIsUsed extends Rule {
 
     const iconFontPlugin = () => {
       return {
-        postcssPlugin: "postcss-icon-font-is-used",
+        postcssPlugin: 'postcss-icon-font-is-used',
         Once(root) {
           root.nodes.forEach((rule) => {
-            if (rule.name === "font-face") {
+            if (rule.name === 'font-face') {
               for (const declaration of rule.nodes) {
-                if (declaration.prop === "font-family") {
+                if (declaration.prop === 'font-family') {
                   // check if font-family matches candidate list
                   const match = isIconFontDeclaration(declaration.value);
                   if (match) {
@@ -106,22 +91,20 @@ export class NoIconFontIsUsed extends Rule {
       })
       .catch((err) => {
         console.warn(`Failed to process CSS`, err.message);
-        return { css: stylesText };
+        return {css: stylesText};
       });
 
     if (iconFontMatches.length > 0) {
-      return this.warn(
-        "Avoid using icon fonts to improve loading speed and accessibility"
-      );
+      return this.warn('Avoid using icon fonts to improve loading speed and accessibility');
     }
 
     return this.pass();
   }
   meta() {
     return {
-      url: "",
-      title: "Page seems to use icon fonts",
-      info: "",
+      url: '',
+      title: 'Page seems to use icon fonts',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/RuntimeIsPreloaded.ts
+++ b/packages/linter/src/rules/RuntimeIsPreloaded.ts
@@ -1,27 +1,23 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class RuntimeIsPreloaded extends Rule {
-  run({ $ }: Context) {
-    const jsAttr = ["href$='/v0.js'", "rel='preload'", "as='script'"]
-      .map((s) => `[${s}]`)
-      .join("");
+  run({$}: Context) {
+    const jsAttr = ["href$='/v0.js'", "rel='preload'", "as='script'"].map((s) => `[${s}]`).join('');
     const mjsAttr = ["href$='/v0.mjs'", "rel$='preload'"] // preload or modulepreload
       .map((s) => `[${s}]`)
-      .join("");
+      .join('');
     const isPreloaded = $(`link${jsAttr}, link${mjsAttr}`).length > 0;
     return isPreloaded
       ? this.pass()
-      : this.warn(
-          "<link href=https://cdn.ampproject.org/v0.js rel=preload> is missing"
-        );
+      : this.warn('<link href=https://cdn.ampproject.org/v0.js rel=preload> is missing');
   }
   meta() {
     return {
       url:
-        "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading",
-      title: "Runtime is preloaded",
-      info: "",
+        'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading',
+      title: 'Runtime is preloaded',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/SchemaMetadataIsNews.ts
+++ b/packages/linter/src/rules/SchemaMetadataIsNews.ts
@@ -1,28 +1,22 @@
-import { schemaMetadata } from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {schemaMetadata} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class SchemaMetadataIsNews extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     const metadata = schemaMetadata($);
-    const type = metadata["@type"];
-    if (
-      type !== "Article" &&
-      type !== "NewsArticle" &&
-      type !== "ReportageNewsArticle"
-    ) {
-      return this.warn(
-        `@type is not 'Article' or 'NewsArticle' or 'ReportageNewsArticle'`
-      );
+    const type = metadata['@type'];
+    if (type !== 'Article' && type !== 'NewsArticle' && type !== 'ReportageNewsArticle') {
+      return this.warn(`@type is not 'Article' or 'NewsArticle' or 'ReportageNewsArticle'`);
     } else {
       return this.pass(`@type is ${type}`);
     }
   }
   meta() {
     return {
-      url: "",
-      title: "schema.org metadata has news or article type",
-      info: "",
+      url: '',
+      title: 'schema.org metadata has news or article type',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/SchemaMetadataIsRecent.ts
+++ b/packages/linter/src/rules/SchemaMetadataIsRecent.ts
@@ -1,9 +1,9 @@
-import { schemaMetadata } from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {schemaMetadata} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class SchemaMetadataIsRecent extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     const inLastMonth = (time: number) => {
       return time > Date.now() - 30 * 24 * 60 * 60 * 1000 && time < Date.now();
     };

--- a/packages/linter/src/rules/StoryIsMostlyText.ts
+++ b/packages/linter/src/rules/StoryIsMostlyText.ts
@@ -1,9 +1,9 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class StoryIsMostlyText extends Rule {
-  run({ $ }: Context) {
-    const text = $("amp-story").text();
+  run({$}: Context) {
+    const text = $('amp-story').text();
     if (text.length > 100) {
       return this.pass();
     } else {
@@ -12,9 +12,9 @@ export class StoryIsMostlyText extends Rule {
   }
   meta() {
     return {
-      url: "",
-      title: "Text is HTML (and not embedded into video)",
-      info: "",
+      url: '',
+      title: 'Text is HTML (and not embedded into video)',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/StoryMetadataIsV1.ts
+++ b/packages/linter/src/rules/StoryMetadataIsV1.ts
@@ -1,36 +1,26 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class StoryMetadataIsV1 extends Rule {
-  run({ $ }: Context) {
-    const isV1 =
-      $("script[src='https://cdn.ampproject.org/v0/amp-story-1.0.js']").length >
-      0;
+  run({$}: Context) {
+    const isV1 = $("script[src='https://cdn.ampproject.org/v0/amp-story-1.0.js']").length > 0;
     if (!isV1) {
       return this.pass();
     }
-    const attr: string[] = [
-      "title",
-      "publisher",
-      "publisher-logo-src",
-      "poster-portrait-src",
-    ]
+    const attr: string[] = ['title', 'publisher', 'publisher-logo-src', 'poster-portrait-src']
       .map((a) => ($(`amp-story[${a}]`).length > 0 ? false : a))
       .filter(Boolean) as string[];
     if (attr.length > 0) {
-      return this.warn(
-        `<amp-story> is missing required attribute(s): [${attr.join(", ")}]`
-      );
+      return this.warn(`<amp-story> is missing required attribute(s): [${attr.join(', ')}]`);
     } else {
       return this.pass();
     }
   }
   meta() {
     return {
-      url:
-        "https://amp.dev/documentation/components/amp-story/#new-metadata-requirements",
-      title: "Required story metadata attributes in <amp-story> tag",
-      info: "",
+      url: 'https://amp.dev/documentation/components/amp-story/#new-metadata-requirements',
+      title: 'Required story metadata attributes in <amp-story> tag',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/StoryMetadataThumbnailsAreOk.ts
+++ b/packages/linter/src/rules/StoryMetadataThumbnailsAreOk.ts
@@ -1,31 +1,31 @@
-import { ImageSize } from "probe-image-size";
-import * as cheerio from "cheerio";
-import { absoluteUrl, dimensions } from "../helper";
-import { Context, Result, Metadata } from "../index";
-import { Rule } from "../rule";
-import { notPass } from "../filter";
+import {ImageSize} from 'probe-image-size';
+import * as cheerio from 'cheerio';
+import {absoluteUrl, dimensions} from '../helper';
+import {Context, Result, Metadata} from '../index';
+import {Rule} from '../rule';
+import {notPass} from '../filter';
 
 function inlineMetadata($: cheerio.Root) {
-  const e = $("amp-story");
+  const e = $('amp-story');
   const metadata: Metadata = {
-    "poster-landscape-src": e.attr("poster-landscape-src"), // optional
-    "poster-portrait-src": e.attr("poster-portrait-src"),
-    "poster-square-src": e.attr("poster-square-src"), // optional
-    "publisher": e.attr("publisher"),
-    "publisher-logo-src": e.attr("publisher-logo-src"),
-    "title": e.attr("title")
+    'poster-landscape-src': e.attr('poster-landscape-src'), // optional
+    'poster-portrait-src': e.attr('poster-portrait-src'),
+    'poster-square-src': e.attr('poster-square-src'), // optional
+    'publisher': e.attr('publisher'),
+    'publisher-logo-src': e.attr('publisher-logo-src'),
+    'title': e.attr('title'),
   };
   return metadata;
 }
-const outputMessageMap: { [key: string]: string } = {
-  isPortrait: " a 3:4 aspect ratio",
-  isSquare: " a 1:1 aspect ratio",
-  isRaster: " of type .jpeg, .gif, .png, or .webp",
-  isLandscape: " a 4:3 aspect ratio",
-  isAtLeast96x96: " at least 96x96 or larger",
-  isAtLeast640x640: " 640x640px or larger",
-  isAtLeast640x853: " 640x853px or larger",
-  isAtLeast853x640: " 853x640px or larger"
+const outputMessageMap: {[key: string]: string} = {
+  isPortrait: ' a 3:4 aspect ratio',
+  isSquare: ' a 1:1 aspect ratio',
+  isRaster: ' of type .jpeg, .gif, .png, or .webp',
+  isLandscape: ' a 4:3 aspect ratio',
+  isAtLeast96x96: ' at least 96x96 or larger',
+  isAtLeast640x640: ' 640x640px or larger',
+  isAtLeast640x853: ' 640x853px or larger',
+  isAtLeast853x640: ' 853x640px or larger',
 };
 
 export class StoryMetadataThumbnailsAreOk extends Rule {
@@ -33,30 +33,28 @@ export class StoryMetadataThumbnailsAreOk extends Rule {
     // Requirements are from
     // https://amp.dev/documentation/components/amp-story/#poster-guidelines-for-poster-portrait-src-poster-landscape-src-and-poster-square-src
     // Last Updated: July 8th, 2020
-    function isSquare({ width, height }: ImageSize) {
+    function isSquare({width, height}: ImageSize) {
       return width > 0.9 * height && width < 1.1 * height;
     }
-    function isPortrait({ width, height }: ImageSize) {
+    function isPortrait({width, height}: ImageSize) {
       return width > 0.65 * height && width < 0.85 * height;
     }
-    function isLandscape({ width, height }: ImageSize) {
+    function isLandscape({width, height}: ImageSize) {
       return height > 0.65 * width && height < 0.85 * width;
     }
-    function isRaster({ mime }: ImageSize) {
-      return ["image/jpeg", "image/gif", "image/png", "image/webp"].includes(
-        mime
-      );
+    function isRaster({mime}: ImageSize) {
+      return ['image/jpeg', 'image/gif', 'image/png', 'image/webp'].includes(mime);
     }
-    function isAtLeast96x96({ width, height }: ImageSize) {
+    function isAtLeast96x96({width, height}: ImageSize) {
       return width >= 96 && height >= 96;
     }
-    function isAtLeast640x640({ width, height }: ImageSize) {
+    function isAtLeast640x640({width, height}: ImageSize) {
       return width >= 640 && height >= 640;
     }
-    function isAtLeast640x853({ width, height }: ImageSize) {
+    function isAtLeast640x853({width, height}: ImageSize) {
       return width >= 640 && height >= 853;
     }
-    function isAtLeast853x640({ width, height }: ImageSize) {
+    function isAtLeast853x640({width, height}: ImageSize) {
       return width >= 853 && height >= 640;
     }
     const metadata = inlineMetadata(context.$);
@@ -73,7 +71,7 @@ export class StoryMetadataThumbnailsAreOk extends Rule {
       }
       try {
         const info = await dimensions(context, url);
-        const failed = expected.filter(fn => !fn(info)).map(fn => fn.name);
+        const failed = expected.filter((fn) => !fn(info)).map((fn) => fn.name);
 
         return failed.length === 0
           ? this.pass(`> ${attr} = ${metadata[attr]}`)
@@ -81,23 +79,23 @@ export class StoryMetadataThumbnailsAreOk extends Rule {
       } catch (e) {
         const s = absoluteUrl(url, context.url);
         switch (e.message) {
-          case "unrecognized file format":
+          case 'unrecognized file format':
             return this.fail(`[${attr}] (${s}) unrecognized file format`);
-          case "bad status code: 404":
+          case 'bad status code: 404':
             return this.fail(`[${attr}] (${s}) 404 file not found`);
           default:
             return this.fail(`[${attr}] (${s}) error: ${JSON.stringify(e)}`);
         }
       }
     };
-    let formatForHumans: (
+    let formatForHumans: (attr: string, url: any, failed: string) => string = function (
       attr: string,
       url: any,
       failed: string
-    ) => string = function (attr: string, url: any, failed: string) {
+    ) {
       let m = `${attr} should be`;
-      failed.split(",").forEach(function (el) {
-        m = m + outputMessageMap[el] + " and";
+      failed.split(',').forEach(function (el) {
+        m = m + outputMessageMap[el] + ' and';
       });
 
       //Remove the last ' and' + tack on the src
@@ -105,33 +103,20 @@ export class StoryMetadataThumbnailsAreOk extends Rule {
       return m;
     };
     const res = [
-      assert("publisher-logo-src", true, [isRaster, isSquare, isAtLeast96x96]),
-      assert("poster-portrait-src", true, [
-        isRaster,
-        isPortrait,
-        isAtLeast640x853
-      ]),
-      assert("poster-square-src", false, [
-        isRaster,
-        isSquare,
-        isAtLeast640x640
-      ]),
-      assert("poster-landscape-src", false, [
-        isRaster,
-        isLandscape,
-        isAtLeast853x640
-      ])
+      assert('publisher-logo-src', true, [isRaster, isSquare, isAtLeast96x96]),
+      assert('poster-portrait-src', true, [isRaster, isPortrait, isAtLeast640x853]),
+      assert('poster-square-src', false, [isRaster, isSquare, isAtLeast640x640]),
+      assert('poster-landscape-src', false, [isRaster, isLandscape, isAtLeast853x640]),
     ];
     return (await Promise.all(res)).filter(notPass);
   }
   meta() {
     return {
-      url:
-        "https://amp.dev/documentation/components/amp-story/#new-metadata-requirements",
-      title: "AMP Story preview metadata is correct size and aspect ratio",
-      info: ""
+      url: 'https://amp.dev/documentation/components/amp-story/#new-metadata-requirements',
+      title: 'AMP Story preview metadata is correct size and aspect ratio',
+      info: '',
     };
   }
 }
 
-export { inlineMetadata as _inlineMetadata };
+export {inlineMetadata as _inlineMetadata};

--- a/packages/linter/src/rules/StoryRuntimeIsV1.ts
+++ b/packages/linter/src/rules/StoryRuntimeIsV1.ts
@@ -1,21 +1,16 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class StoryRuntimeIsV1 extends Rule {
-  run({ $ }: Context) {
-    const isV1 =
-      $("script[src='https://cdn.ampproject.org/v0/amp-story-1.0.js']").length >
-      0;
-    return isV1
-      ? this.pass()
-      : this.fail("amp-story-1.0.js not used (probably 0.1?)");
+  run({$}: Context) {
+    const isV1 = $("script[src='https://cdn.ampproject.org/v0/amp-story-1.0.js']").length > 0;
+    return isV1 ? this.pass() : this.fail('amp-story-1.0.js not used (probably 0.1?)');
   }
   meta() {
     return {
-      url:
-        "https://amp.dev/documentation/components/amp-story/#migrating-from-0.1-to-1.0",
-      title: "AMP Story v1.0 is used",
-      info: "",
+      url: 'https://amp.dev/documentation/components/amp-story/#migrating-from-0.1-to-1.0',
+      title: 'AMP Story v1.0 is used',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/SxgAmppkgIsForwarded.ts
+++ b/packages/linter/src/rules/SxgAmppkgIsForwarded.ts
@@ -1,34 +1,31 @@
-import { URL } from "url";
-import { default as fetch } from "node-fetch";
-import { fetchToCurl } from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {URL} from 'url';
+import {default as fetch} from 'node-fetch';
+import {fetchToCurl} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
 export class SxgAmppkgIsForwarded extends Rule {
-  async run({ url, headers }: Context) {
+  async run({url, headers}: Context) {
     const validity = (() => {
-      const { protocol, host } = new URL(url);
+      const {protocol, host} = new URL(url);
       return `${protocol}//${host}/amppkg/validity`;
     })();
-    const res = await fetch(validity, { headers });
-    const contentType = res.headers.get("content-type");
+    const res = await fetch(validity, {headers});
+    const contentType = res.headers.get('content-type');
     // Substring instead of equality because some server provide a
     // charset--probably incorrectly, but seems to work, so...
-    return res.ok && contentType && contentType.includes("application/cbor")
+    return res.ok && contentType && contentType.includes('application/cbor')
       ? this.pass()
       : this.fail(
-          `/amppkg/ not forwarded to amppackager [debug: ${fetchToCurl(
-            validity,
-            {
-              headers,
-            }
-          )}]`
+          `/amppkg/ not forwarded to amppackager [debug: ${fetchToCurl(validity, {
+            headers,
+          })}]`
         );
   }
   meta() {
     return {
-      url: "",
-      title: "/amppkg/ is forwarded correctly",
-      info: "",
+      url: '',
+      title: '/amppkg/ is forwarded correctly',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/SxgContentNegotiationIsOk.ts
+++ b/packages/linter/src/rules/SxgContentNegotiationIsOk.ts
@@ -1,16 +1,16 @@
-import { default as fetch } from "node-fetch";
-import { Context } from "../index";
-import { Rule } from "../rule";
-import { fetchToCurl } from "../helper";
+import {default as fetch} from 'node-fetch';
+import {Context} from '../index';
+import {Rule} from '../rule';
+import {fetchToCurl} from '../helper';
 
 export class SxgContentNegotiationIsOk extends Rule {
-  async run({ url, headers }: Context) {
+  async run({url, headers}: Context) {
     const opt1 = {
-      headers: Object.assign({ accept: "text/html" }, headers),
+      headers: Object.assign({accept: 'text/html'}, headers),
     };
     const res1 = await fetch(url, opt1);
-    const hdr1 = res1.headers.get("content-type") || "";
-    if (hdr1.indexOf("application/signed-exchange") !== -1) {
+    const hdr1 = res1.headers.get('content-type') || '';
+    if (hdr1.indexOf('application/signed-exchange') !== -1) {
       return this.fail(
         `[content-type: application/signed-exchange] incorrectly returned for [accept: text/html] [debug: ${fetchToCurl(
           url,
@@ -19,14 +19,11 @@ export class SxgContentNegotiationIsOk extends Rule {
       );
     }
     const opt2 = {
-      headers: Object.assign(
-        { accept: "application/signed-exchange;v=b3" },
-        headers
-      ),
+      headers: Object.assign({accept: 'application/signed-exchange;v=b3'}, headers),
     };
     const res2 = await fetch(url, opt2);
-    const hdr2 = res2.headers.get("content-type") || "";
-    if (hdr2.indexOf("application/signed-exchange") !== -1) {
+    const hdr2 = res2.headers.get('content-type') || '';
+    if (hdr2.indexOf('application/signed-exchange') !== -1) {
       return this.fail(
         `[content-type: application/signed-exchange] incorrectly returned for [accept: application/signed-exchange;v=b3] [debug: ${fetchToCurl(
           url,
@@ -37,15 +34,15 @@ export class SxgContentNegotiationIsOk extends Rule {
     const opt3 = {
       headers: Object.assign(
         {
-          "accept": "application/signed-exchange;v=b3",
-          "amp-cache-transform": `google;v="1"`,
+          'accept': 'application/signed-exchange;v=b3',
+          'amp-cache-transform': `google;v="1"`,
         },
         headers
       ),
     };
     const res3 = await fetch(url, opt3);
-    const hdr3 = res3.headers.get("content-type") || "";
-    if (hdr3.indexOf("application/signed-exchange") === -1) {
+    const hdr3 = res3.headers.get('content-type') || '';
+    if (hdr3.indexOf('application/signed-exchange') === -1) {
       return this.fail(
         `[content-type: application/signed-exchange] not returned for [accept: application/signed-exchange;v=b3], [amp-cache-transform: google;v="1"] [debug: ${fetchToCurl(
           url,
@@ -57,9 +54,9 @@ export class SxgContentNegotiationIsOk extends Rule {
   }
   meta() {
     return {
-      url: "",
-      title: "content negotiation is correct",
-      info: "",
+      url: '',
+      title: 'content negotiation is correct',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/SxgVaryOnAcceptAct.ts
+++ b/packages/linter/src/rules/SxgVaryOnAcceptAct.ts
@@ -1,31 +1,26 @@
-import { default as fetch } from "node-fetch";
-import { fetchToCurl } from "../helper";
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {default as fetch} from 'node-fetch';
+import {fetchToCurl} from '../helper';
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class SxgVaryOnAcceptAct extends Rule {
-  async run({ url, headers }: Context) {
-    headers.accept = "text/html,application/signed-exchange;v=b3";
-    const res = await fetch(url, { headers });
-    const debug = `debug: ${fetchToCurl(url, { headers })}`;
-    const vary = ("" + res.headers.get("vary"))
-      .split(",")
-      .map((s) => s.toLowerCase().trim());
-    if (vary.length == 0)
-      return this.fail(`[vary] header is missing [${debug}]`);
-    if (!vary.includes("amp-cache-transform"))
-      return this.fail(
-        `[vary] header is missing value [amp-cache-transform] [${debug}]`
-      );
-    if (!vary.includes("accept"))
+  async run({url, headers}: Context) {
+    headers.accept = 'text/html,application/signed-exchange;v=b3';
+    const res = await fetch(url, {headers});
+    const debug = `debug: ${fetchToCurl(url, {headers})}`;
+    const vary = ('' + res.headers.get('vary')).split(',').map((s) => s.toLowerCase().trim());
+    if (vary.length == 0) return this.fail(`[vary] header is missing [${debug}]`);
+    if (!vary.includes('amp-cache-transform'))
+      return this.fail(`[vary] header is missing value [amp-cache-transform] [${debug}]`);
+    if (!vary.includes('accept'))
       return this.fail(`[vary] header is missing value [accept] [${debug}]`);
     return this.pass();
   }
   meta() {
     return {
-      url: "",
-      title: "vary header is correct",
-      info: "",
+      url: '',
+      title: 'vary header is correct',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/TitleMeetsLengthCriteria.ts
+++ b/packages/linter/src/rules/TitleMeetsLengthCriteria.ts
@@ -1,22 +1,22 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
-import chalk from "chalk";
+import {Context} from '../index';
+import {Rule} from '../rule';
+import chalk from 'chalk';
 
 export class TitleMeetsLengthCriteria extends Rule {
-  run({ $ }: Context) {
-    const e = $("amp-story[title]");
+  run({$}: Context) {
+    const e = $('amp-story[title]');
     const PASSING_LEN = 90;
 
     return (e[0] as cheerio.TagElement).attribs.title.length > PASSING_LEN
-      ? this.warn("Title is too long")
+      ? this.warn('Title is too long')
       : this.pass();
   }
   meta() {
     return {
       url:
-        "https://developers.google.com/search/docs/guides/web-stories-creation-best-practices#seo",
-      title: "Title is ninety characters or less",
-      info: "",
+        'https://developers.google.com/search/docs/guides/web-stories-creation-best-practices#seo',
+      title: 'Title is ninety characters or less',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/VideosAreSubtitled.ts
+++ b/packages/linter/src/rules/VideosAreSubtitled.ts
@@ -1,10 +1,10 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class VideosAreSubtitled extends Rule {
-  run({ $ }: Context) {
-    const numOfSubtitleElems = $("track").length;
-    const numOfVideoElems = $("amp-video").length;
+  run({$}: Context) {
+    const numOfSubtitleElems = $('track').length;
+    const numOfVideoElems = $('amp-video').length;
 
     //Are there any <amp-video> tags? If so, is there at least 1 <track>?
     return numOfVideoElems > 0 && numOfSubtitleElems <= 0
@@ -13,9 +13,9 @@ export class VideosAreSubtitled extends Rule {
   }
   meta() {
     return {
-      url: "https://blog.amp.dev/2020/02/12/seo-for-amp-stories/",
-      title: "Videos are subtitled",
-      info: "",
+      url: 'https://blog.amp.dev/2020/02/12/seo-for-amp-stories/',
+      title: 'Videos are subtitled',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/VideosHaveAltText.ts
+++ b/packages/linter/src/rules/VideosHaveAltText.ts
@@ -1,11 +1,11 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class VideosHaveAltText extends Rule {
-  run({ $ }: Context) {
+  run({$}: Context) {
     let vidsWithoutAlt = 0;
 
-    $("amp-video").each(function (i, elem: cheerio.TagElement) {
+    $('amp-video').each(function (i, elem: cheerio.TagElement) {
       if (!elem.attribs.title) {
         vidsWithoutAlt += 1;
       }
@@ -17,9 +17,9 @@ export class VideosHaveAltText extends Rule {
   }
   meta() {
     return {
-      url: "https://blog.amp.dev/2020/02/12/seo-for-amp-stories/",
-      title: "Videos contain alt text",
-      info: "",
+      url: 'https://blog.amp.dev/2020/02/12/seo-for-amp-stories/',
+      title: 'Videos contain alt text',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/rules/ViewportDisablesTapDelay.ts
+++ b/packages/linter/src/rules/ViewportDisablesTapDelay.ts
@@ -1,13 +1,13 @@
-import { Context } from "../index";
-import { Rule } from "../rule";
+import {Context} from '../index';
+import {Rule} from '../rule';
 
 export class ViewportDisablesTapDelay extends Rule {
-  run({ $ }: Context) {
-    const viewport = $("meta[name=viewport]")[0] as cheerio.TagElement;
+  run({$}: Context) {
+    const viewport = $('meta[name=viewport]')[0] as cheerio.TagElement;
     if (!viewport) {
       return this.pass();
     }
-    return viewport.attribs.content !== "width=device-width"
+    return viewport.attribs.content !== 'width=device-width'
       ? this.warn(
           `Viewport width is not set to device width: '<meta name="viewport" content="width=device-width">'`
         )
@@ -15,11 +15,9 @@ export class ViewportDisablesTapDelay extends Rule {
   }
   meta() {
     return {
-      url:
-        "https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away",
-      title:
-        "Set viewport width to match the device to disable touch delay causing FID.",
-      info: "",
+      url: 'https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away',
+      title: 'Set viewport width to match the device to disable touch delay causing FID.',
+      info: '',
     };
   }
 }

--- a/packages/linter/src/validate.ts
+++ b/packages/linter/src/validate.ts
@@ -1,10 +1,8 @@
-import { getInstance } from "amphtml-validator";
-import { existsSync } from "fs";
+import {getInstance} from 'amphtml-validator';
+import {existsSync} from 'fs';
 
 // If validator.js exists locally, use that, otherwise fetch over network.
-const validator = existsSync("validator.js")
-  ? getInstance("validator.js")
-  : getInstance();
+const validator = existsSync('validator.js') ? getInstance('validator.js') : getInstance();
 
 export async function validate(s: string) {
   const v = await validator;

--- a/packages/linter/tests/helper.test.ts
+++ b/packages/linter/tests/helper.test.ts
@@ -1,8 +1,8 @@
-import cheerio from "cheerio";
-import { restore as nockRestore } from "nock";
-import { withFixture, assertEqual, runCheerioFn } from "./lib";
-import { schemaMetadata, corsEndpoints, isTransformedAmp } from "../src/helper";
-import { _inlineMetadata as inlineMetadata } from "../src/rules/StoryMetadataThumbnailsAreOk";
+import cheerio from 'cheerio';
+import {restore as nockRestore} from 'nock';
+import {withFixture, assertEqual, runCheerioFn} from './lib';
+import {schemaMetadata, corsEndpoints, isTransformedAmp} from '../src/helper';
+import {_inlineMetadata as inlineMetadata} from '../src/rules/StoryMetadataThumbnailsAreOk';
 
 afterEach(() => {
   nockRestore();
@@ -10,33 +10,31 @@ afterEach(() => {
 
 describe(`helper ${schemaMetadata.name}`, () => {
   it(schemaMetadata.name, async () => {
-    return withFixture("getschemametadata", () =>
+    return withFixture('getschemametadata', () =>
       assertEqual(
         runCheerioFn(
           schemaMetadata,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         ),
         {
-          "@context": "http://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
+          '@context': 'http://schema.org',
+          '@type': 'BreadcrumbList',
+          'itemListElement': [
             {
-              "@type": "ListItem",
-              "item": {
-                "@id":
-                  "https://ampbyexample.com/#/stories#stories/introduction",
-                "name": "Introduction",
+              '@type': 'ListItem',
+              'item': {
+                '@id': 'https://ampbyexample.com/#/stories#stories/introduction',
+                'name': 'Introduction',
               },
-              "position": 1,
+              'position': 1,
             },
             {
-              "@type": "ListItem",
-              "item": {
-                "@id":
-                  "https://ampbyexample.com/stories/introduction/amp_story_hello_world/",
-                "name": " AMP Story Hello World",
+              '@type': 'ListItem',
+              'item': {
+                '@id': 'https://ampbyexample.com/stories/introduction/amp_story_hello_world/',
+                'name': ' AMP Story Hello World',
               },
-              "position": 2,
+              'position': 2,
             },
           ],
         }
@@ -47,63 +45,59 @@ describe(`helper ${schemaMetadata.name}`, () => {
 
 describe(`helper ${inlineMetadata.name}`, () => {
   it(inlineMetadata.name, async () => {
-    return withFixture("getinlinemetadata", () =>
+    return withFixture('getinlinemetadata', () =>
       assertEqual(
-        runCheerioFn(
-          inlineMetadata,
-          "https://ithinkihaveacat.github.io/hello-world-amp-story/"
-        ),
+        runCheerioFn(inlineMetadata, 'https://ithinkihaveacat.github.io/hello-world-amp-story/'),
         {
-          "poster-portrait-src": [
-            "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/",
-            "Cantilever_bridge_human_model.jpg/",
-            "627px-Cantilever_bridge_human_model.jpg",
-          ].join(""),
-          "publisher": "Michael Stillwell",
-          "publisher-logo-src":
-            "https://s.gravatar.com/avatar/3928085cafc1e496fb3d990a9959f233?s=150",
-          "title": "Hello, Ken Burns",
+          'poster-portrait-src': [
+            'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/',
+            'Cantilever_bridge_human_model.jpg/',
+            '627px-Cantilever_bridge_human_model.jpg',
+          ].join(''),
+          'publisher': 'Michael Stillwell',
+          'publisher-logo-src':
+            'https://s.gravatar.com/avatar/3928085cafc1e496fb3d990a9959f233?s=150',
+          'title': 'Hello, Ken Burns',
         }
       )
     );
   });
 });
 
-describe("helper corsEndpoints", () => {
+describe('helper corsEndpoints', () => {
   it(`${corsEndpoints.name} - AMP`, async () => {
-    return withFixture("corsendpoints1", () =>
-      assertEqual(
-        runCheerioFn(corsEndpoints, "https://swift-track.glitch.me/"),
-        ["https://ampbyexample.com/json/examples.json"]
-      )
+    return withFixture('corsendpoints1', () =>
+      assertEqual(runCheerioFn(corsEndpoints, 'https://swift-track.glitch.me/'), [
+        'https://ampbyexample.com/json/examples.json',
+      ])
     );
   });
 
   it(`${corsEndpoints.name} - AMP Story`, async () => {
-    return withFixture("corsendpoints2", () =>
+    return withFixture('corsendpoints2', () =>
       assertEqual(
         runCheerioFn(
           corsEndpoints,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         ),
-        ["https://ampbyexample.com/json/bookend.json"]
+        ['https://ampbyexample.com/json/bookend.json']
       )
     );
   });
 });
 
-describe("helper isTransformedAmp", () => {
-  it("isTransformedAmp with current transform value", async () => {
+describe('helper isTransformedAmp', () => {
+  it('isTransformedAmp with current transform value', async () => {
     const $ = cheerio.load("<html transformed='self;v=1'><body></body></html>");
     expect(isTransformedAmp($)).toEqual(true);
   });
 
-  it("isTransformedAmp with different transform value", async () => {
+  it('isTransformedAmp with different transform value', async () => {
     const $ = cheerio.load("<html transformed='self;v=2'><body></body></html>");
     expect(isTransformedAmp($)).toEqual(true);
   });
 
-  it("isTransformedAmp with current transform value", async () => {
+  it('isTransformedAmp with current transform value', async () => {
     const $ = cheerio.load("<html other='self;v=1'><body></body></html>");
     expect(isTransformedAmp($)).toEqual(false);
   });

--- a/packages/linter/tests/lib.ts
+++ b/packages/linter/tests/lib.ts
@@ -1,18 +1,18 @@
-const FIXTURES = "fixtures";
+const FIXTURES = 'fixtures';
 
-import { existsSync, readFileSync } from "fs";
+import {existsSync, readFileSync} from 'fs';
 
-import * as cheerio from "cheerio";
-import debug from "debug";
-import { diffJson as diff } from "diff";
-import { back as nockBack } from "nock";
-import { default as fetch } from "node-fetch";
+import * as cheerio from 'cheerio';
+import debug from 'debug';
+import {diffJson as diff} from 'diff';
+import {back as nockBack} from 'nock';
+import {default as fetch} from 'node-fetch';
 
-import throat from "throat";
-import { Status, Result, guessMode } from "../src";
-import { RuleConstructor } from "../src/rule";
+import throat from 'throat';
+import {Status, Result, guessMode} from '../src';
+import {RuleConstructor} from '../src/rule';
 
-const log = debug("linter");
+const log = debug('linter');
 
 nockBack.fixtures = `${__dirname}/${FIXTURES}`;
 
@@ -24,17 +24,17 @@ export const withFixture = throat(
     const fixturePath = `${fixtureName}.json`;
     if (existsSync(`${nockBack.fixtures}/${fixturePath}`)) {
       log(`nocking HTTP requests with fixture [${fixturePath}]`);
-      nockBack.setMode("lockdown");
-      const { nockDone } = await nockBack(fixturePath);
+      nockBack.setMode('lockdown');
+      const {nockDone} = await nockBack(fixturePath);
       const res = await fn();
       nockDone();
       return res;
     } else {
       log(`recording HTTP requests to fixture [${fixturePath}] ...`);
-      nockBack.setMode("record");
-      const { nockDone } = await nockBack(fixturePath);
+      nockBack.setMode('record');
+      const {nockDone} = await nockBack(fixturePath);
       const res = await fn();
-      return new Promise<T>(resolve => {
+      return new Promise<T>((resolve) => {
         setTimeout(() => {
           // wait for probe-image-size's aborts to settle
           nockDone();
@@ -71,20 +71,20 @@ export async function assertStatus(
     if (expectedStatus === Status.PASS) {
       return;
     } else {
-      throw new Error("no results returned");
+      throw new Error('no results returned');
     }
   }
   if (actual.length > 1) {
-    throw new Error("multiple results returned");
+    throw new Error('multiple results returned');
   }
   const actualStatus = actual[0].status;
   if (actualStatus === expectedStatus) {
     return;
   } else {
     throw new Error(
-      `actual status: ${JSON.stringify(
-        actualStatus
-      )}, expected status: ${JSON.stringify(expectedStatus)}`
+      `actual status: ${JSON.stringify(actualStatus)}, expected status: ${JSON.stringify(
+        expectedStatus
+      )}`
     );
   }
 }
@@ -93,10 +93,7 @@ export async function assertEqual<T extends object>(
   actual: T | Promise<T>,
   expected: T | Promise<T>
 ) {
-  const res = diff(
-    await Promise.resolve(expected),
-    await Promise.resolve(actual)
-  );
+  const res = diff(await Promise.resolve(expected), await Promise.resolve(actual));
   if (!res || res.length !== 1) {
     const as = JSON.stringify(await Promise.resolve(actual));
     const es = JSON.stringify(await Promise.resolve(expected));
@@ -109,10 +106,7 @@ export async function assertNotEqual<T extends object>(
   actual: T | Promise<T>,
   expected: T | Promise<T>
 ) {
-  const res = diff(
-    await Promise.resolve(expected),
-    await Promise.resolve(actual)
-  );
+  const res = diff(await Promise.resolve(expected), await Promise.resolve(actual));
   if (res && res.length === 1) {
     const as = JSON.stringify(await Promise.resolve(actual));
     const es = JSON.stringify(await Promise.resolve(expected));
@@ -127,9 +121,7 @@ export async function assertMatch<T extends object>(
 ) {
   const s = JSON.stringify(await Promise.resolve(actual));
   if (!s.match(expected)) {
-    throw new Error(
-      `actual: ${s}, expected regexp match: ${expected.toString()}`
-    );
+    throw new Error(`actual: ${s}, expected regexp match: ${expected.toString()}`);
   }
 }
 
@@ -156,14 +148,14 @@ export async function assertFnList(
 }
 
 export async function runLocalTest(ctor: RuleConstructor, fixture: string) {
-  const body = readFileSync(fixture, { encoding: "utf8" });
+  const body = readFileSync(fixture, {encoding: 'utf8'});
   const $ = cheerio.load(body);
   const context = {
     $,
     headers: {},
-    url: "",
-    raw: { body, headers: {} },
-    mode: guessMode($)
+    url: '',
+    raw: {body, headers: {}},
+    mode: guessMode($),
   };
   const rule = new ctor();
   return Promise.resolve(rule.run(context));
@@ -177,8 +169,8 @@ export async function runNetworkTest(ctor: RuleConstructor, url: string) {
     $,
     headers: {},
     url,
-    raw: { body, headers: {} },
-    mode: guessMode($)
+    raw: {body, headers: {}},
+    mode: guessMode($),
   };
   const rule = new ctor();
   return Promise.resolve(rule.run(context));

--- a/packages/linter/tests/local.test.ts
+++ b/packages/linter/tests/local.test.ts
@@ -1,34 +1,28 @@
-import {
-  assertPass,
-  runLocalTest,
-  assertWarn,
-  assertFail,
-  assertInfo,
-} from "./lib";
-import { AmpImgAmpPixelPreferred } from "../src/rules/AmpImgAmpPixelPreferred";
-import { AmpImgPlaceholderIsDataUri } from "../src/rules/AmpImgPlaceholderIsDataUri";
-import { MetaCharsetIsFirst } from "../src/rules/MetaCharsetIsFirst";
-import { RuntimeIsPreloaded } from "../src/rules/RuntimeIsPreloaded";
-import { SchemaMetadataIsNews } from "../src/rules/SchemaMetadataIsNews";
-import { StoryRuntimeIsV1 } from "../src/rules/StoryRuntimeIsV1";
-import { ImagesHaveAltText } from "../src/rules/ImagesHaveAltText";
-import { MetadataIncludesOGImageSrc } from "../src/rules/MetadataIncludesOGImageSrc";
-import { VideosHaveAltText } from "../src/rules/VideosHaveAltText";
-import { VideosAreSubtitled } from "../src/rules/VideosAreSubtitled";
-import { BookendExists } from "../src/rules/BookendExists";
-import { TitleMeetsLengthCriteria } from "../src/rules/TitleMeetsLengthCriteria";
-import { IsTransformedAmp } from "../src/rules/IsTransformedAmp";
-import { ModuleRuntimeUsed } from "../src/rules/ModuleRuntimeUsed";
-import { BlockingExtensionsPreloaded } from "../src/rules/BlockingExtensionsPreloaded";
-import { FontsArePreloaded } from "../src/rules/FontsArePreloaded";
-import { HeroImageIsDefined } from "../src/rules/HeroImageIsDefined";
-import { FastGoogleFontsDisplay } from "../src/rules/FastGoogleFontsDisplay";
-import { NoIconFontIsUsed } from "../src/rules/NoIconFontIsUsed";
-import { GoogleFontPreconnect } from "../src/rules/GoogleFontPreconnect";
-import { BoilerplateIsRemoved } from "../src/rules/BoilerplateIsRemoved";
-import { AmpImgUsesSrcSet } from "../src/rules/AmpImgUsesSrcSet";
-import { ViewportDisablesTapDelay } from "../src/rules/ViewportDisablesTapDelay";
-import { IsUsingLatestComponentVersion } from "../src/rules/IsUsingLatestComponentVersion";
+import {assertPass, runLocalTest, assertWarn, assertFail, assertInfo} from './lib';
+import {AmpImgAmpPixelPreferred} from '../src/rules/AmpImgAmpPixelPreferred';
+import {AmpImgPlaceholderIsDataUri} from '../src/rules/AmpImgPlaceholderIsDataUri';
+import {MetaCharsetIsFirst} from '../src/rules/MetaCharsetIsFirst';
+import {RuntimeIsPreloaded} from '../src/rules/RuntimeIsPreloaded';
+import {SchemaMetadataIsNews} from '../src/rules/SchemaMetadataIsNews';
+import {StoryRuntimeIsV1} from '../src/rules/StoryRuntimeIsV1';
+import {ImagesHaveAltText} from '../src/rules/ImagesHaveAltText';
+import {MetadataIncludesOGImageSrc} from '../src/rules/MetadataIncludesOGImageSrc';
+import {VideosHaveAltText} from '../src/rules/VideosHaveAltText';
+import {VideosAreSubtitled} from '../src/rules/VideosAreSubtitled';
+import {BookendExists} from '../src/rules/BookendExists';
+import {TitleMeetsLengthCriteria} from '../src/rules/TitleMeetsLengthCriteria';
+import {IsTransformedAmp} from '../src/rules/IsTransformedAmp';
+import {ModuleRuntimeUsed} from '../src/rules/ModuleRuntimeUsed';
+import {BlockingExtensionsPreloaded} from '../src/rules/BlockingExtensionsPreloaded';
+import {FontsArePreloaded} from '../src/rules/FontsArePreloaded';
+import {HeroImageIsDefined} from '../src/rules/HeroImageIsDefined';
+import {FastGoogleFontsDisplay} from '../src/rules/FastGoogleFontsDisplay';
+import {NoIconFontIsUsed} from '../src/rules/NoIconFontIsUsed';
+import {GoogleFontPreconnect} from '../src/rules/GoogleFontPreconnect';
+import {BoilerplateIsRemoved} from '../src/rules/BoilerplateIsRemoved';
+import {AmpImgUsesSrcSet} from '../src/rules/AmpImgUsesSrcSet';
+import {ViewportDisablesTapDelay} from '../src/rules/ViewportDisablesTapDelay';
+import {IsUsingLatestComponentVersion} from '../src/rules/IsUsingLatestComponentVersion';
 
 describe(AmpImgAmpPixelPreferred.name, () => {
   it(`${AmpImgAmpPixelPreferred.name} - <amp-img height="1" width="1">`, async () => {
@@ -100,55 +94,37 @@ describe(AmpImgPlaceholderIsDataUri, () => {
 describe(AmpImgUsesSrcSet.name, () => {
   it(`${AmpImgUsesSrcSet.name} - responsive - no srcset`, async () => {
     return assertWarn(
-      runLocalTest(
-        AmpImgUsesSrcSet,
-        `${__dirname}/local/AmpImgUsesSrcSet-1/source.html`
-      )
+      runLocalTest(AmpImgUsesSrcSet, `${__dirname}/local/AmpImgUsesSrcSet-1/source.html`)
     );
   });
 
   it(`${AmpImgUsesSrcSet.name} - svg`, async () => {
     return assertPass(
-      runLocalTest(
-        AmpImgUsesSrcSet,
-        `${__dirname}/local/AmpImgUsesSrcSet-2/source.html`
-      )
+      runLocalTest(AmpImgUsesSrcSet, `${__dirname}/local/AmpImgUsesSrcSet-2/source.html`)
     );
   });
 
   it(`${AmpImgUsesSrcSet.name} - fixed`, async () => {
     return assertPass(
-      runLocalTest(
-        AmpImgUsesSrcSet,
-        `${__dirname}/local/AmpImgUsesSrcSet-3/source.html`
-      )
+      runLocalTest(AmpImgUsesSrcSet, `${__dirname}/local/AmpImgUsesSrcSet-3/source.html`)
     );
   });
 
   it(`${AmpImgUsesSrcSet.name} - fixed-height`, async () => {
     return assertPass(
-      runLocalTest(
-        AmpImgUsesSrcSet,
-        `${__dirname}/local/AmpImgUsesSrcSet-4/source.html`
-      )
+      runLocalTest(AmpImgUsesSrcSet, `${__dirname}/local/AmpImgUsesSrcSet-4/source.html`)
     );
   });
 
   it(`${AmpImgUsesSrcSet.name} - srcset`, async () => {
     return assertPass(
-      runLocalTest(
-        AmpImgUsesSrcSet,
-        `${__dirname}/local/AmpImgUsesSrcSet-5/source.html`
-      )
+      runLocalTest(AmpImgUsesSrcSet, `${__dirname}/local/AmpImgUsesSrcSet-5/source.html`)
     );
   });
 
   it(`${AmpImgUsesSrcSet.name} - parent is fixed`, async () => {
     return assertPass(
-      runLocalTest(
-        AmpImgUsesSrcSet,
-        `${__dirname}/local/AmpImgUsesSrcSet-6/source.html`
-      )
+      runLocalTest(AmpImgUsesSrcSet, `${__dirname}/local/AmpImgUsesSrcSet-6/source.html`)
     );
   });
 });
@@ -156,46 +132,31 @@ describe(AmpImgUsesSrcSet.name, () => {
 describe(BoilerplateIsRemoved.name, () => {
   it(`${BoilerplateIsRemoved.name} - boilerplate removed`, async () => {
     return assertPass(
-      runLocalTest(
-        BoilerplateIsRemoved,
-        `${__dirname}/local/BoilerplateIsRemoved-1/source.html`
-      )
+      runLocalTest(BoilerplateIsRemoved, `${__dirname}/local/BoilerplateIsRemoved-1/source.html`)
     );
   });
 
   it(`${BoilerplateIsRemoved.name} - amp-story boilerplate cannot be removed`, async () => {
     return assertPass(
-      runLocalTest(
-        BoilerplateIsRemoved,
-        `${__dirname}/local/BoilerplateIsRemoved-2/source.html`
-      )
+      runLocalTest(BoilerplateIsRemoved, `${__dirname}/local/BoilerplateIsRemoved-2/source.html`)
     );
   });
 
   it(`${BoilerplateIsRemoved.name} - amp-experiment boilerplate avoidable`, async () => {
     return assertInfo(
-      runLocalTest(
-        BoilerplateIsRemoved,
-        `${__dirname}/local/BoilerplateIsRemoved-3/source.html`
-      )
+      runLocalTest(BoilerplateIsRemoved, `${__dirname}/local/BoilerplateIsRemoved-3/source.html`)
     );
   });
 
   it(`${BoilerplateIsRemoved.name} - boilerplate was not removed`, async () => {
     return assertWarn(
-      runLocalTest(
-        BoilerplateIsRemoved,
-        `${__dirname}/local/BoilerplateIsRemoved-4/source.html`
-      )
+      runLocalTest(BoilerplateIsRemoved, `${__dirname}/local/BoilerplateIsRemoved-4/source.html`)
     );
   });
 
   it(`${BoilerplateIsRemoved.name} - not transformed amp`, async () => {
     return assertPass(
-      runLocalTest(
-        BoilerplateIsRemoved,
-        `${__dirname}/local/BoilerplateIsRemoved-5/source.html`
-      )
+      runLocalTest(BoilerplateIsRemoved, `${__dirname}/local/BoilerplateIsRemoved-5/source.html`)
     );
   });
 });
@@ -256,66 +217,42 @@ describe(FastGoogleFontsDisplay.name, () => {
 describe(NoIconFontIsUsed.name, () => {
   it(`${NoIconFontIsUsed.name} - icon font found`, async () => {
     return assertWarn(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-1/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-1/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - no icon font found`, async () => {
     return assertPass(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-2/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-2/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - suspicious class names`, async () => {
     return assertPass(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-3/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-3/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - material icons icon font found`, async () => {
     return assertWarn(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-4/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-4/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - icomoon icon font found`, async () => {
     return assertWarn(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-5/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-5/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - icofont icon font found`, async () => {
     return assertWarn(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-6/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-6/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - nerd font icon font found`, async () => {
     return assertWarn(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-7/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-7/source.html`)
     );
   });
   it(`${NoIconFontIsUsed.name} - icofont with typical font awesome classnames found`, async () => {
     return assertWarn(
-      runLocalTest(
-        NoIconFontIsUsed,
-        `${__dirname}/local/NoIconFontIsUsed-8/source.html`
-      )
+      runLocalTest(NoIconFontIsUsed, `${__dirname}/local/NoIconFontIsUsed-8/source.html`)
     );
   });
 });
@@ -323,26 +260,17 @@ describe(NoIconFontIsUsed.name, () => {
 describe(FontsArePreloaded.name, () => {
   it(`${FontsArePreloaded.name} - preload for font exists`, async () => {
     return assertPass(
-      runLocalTest(
-        FontsArePreloaded,
-        `${__dirname}/local/FontsArePreloaded-1/source.html`
-      )
+      runLocalTest(FontsArePreloaded, `${__dirname}/local/FontsArePreloaded-1/source.html`)
     );
   });
   it(`${FontsArePreloaded.name} - preload for font missing`, async () => {
     return assertInfo(
-      runLocalTest(
-        FontsArePreloaded,
-        `${__dirname}/local/FontsArePreloaded-2/source.html`
-      )
+      runLocalTest(FontsArePreloaded, `${__dirname}/local/FontsArePreloaded-2/source.html`)
     );
   });
   it(`${FontsArePreloaded.name} - all fonts have font-display set`, async () => {
     return assertPass(
-      runLocalTest(
-        FontsArePreloaded,
-        `${__dirname}/local/FontsArePreloaded-3/source.html`
-      )
+      runLocalTest(FontsArePreloaded, `${__dirname}/local/FontsArePreloaded-3/source.html`)
     );
   });
 });
@@ -350,26 +278,17 @@ describe(FontsArePreloaded.name, () => {
 describe(GoogleFontPreconnect.name, () => {
   it(`${GoogleFontPreconnect.name} - dns-prefetch preconnect exists`, async () => {
     return assertPass(
-      runLocalTest(
-        GoogleFontPreconnect,
-        `${__dirname}/local/GoogleFontPreconnect-1/source.html`
-      )
+      runLocalTest(GoogleFontPreconnect, `${__dirname}/local/GoogleFontPreconnect-1/source.html`)
     );
   });
   it(`${GoogleFontPreconnect.name} - preconnect missing`, async () => {
     return assertWarn(
-      runLocalTest(
-        GoogleFontPreconnect,
-        `${__dirname}/local/GoogleFontPreconnect-2/source.html`
-      )
+      runLocalTest(GoogleFontPreconnect, `${__dirname}/local/GoogleFontPreconnect-2/source.html`)
     );
   });
   it(`${GoogleFontPreconnect.name} - dns-prefetch missing`, async () => {
     return assertWarn(
-      runLocalTest(
-        GoogleFontPreconnect,
-        `${__dirname}/local/GoogleFontPreconnect-3/source.html`
-      )
+      runLocalTest(GoogleFontPreconnect, `${__dirname}/local/GoogleFontPreconnect-3/source.html`)
     );
   });
 });
@@ -377,26 +296,17 @@ describe(GoogleFontPreconnect.name, () => {
 describe(HeroImageIsDefined.name, () => {
   it(`${HeroImageIsDefined.name} - data-hero exists`, async () => {
     return assertPass(
-      runLocalTest(
-        HeroImageIsDefined,
-        `${__dirname}/local/HeroImageIsDefined-1/source.html`
-      )
+      runLocalTest(HeroImageIsDefined, `${__dirname}/local/HeroImageIsDefined-1/source.html`)
     );
   });
   it(`${HeroImageIsDefined.name} - no relevant hero images`, async () => {
     return assertPass(
-      runLocalTest(
-        HeroImageIsDefined,
-        `${__dirname}/local/HeroImageIsDefined-2/source.html`
-      )
+      runLocalTest(HeroImageIsDefined, `${__dirname}/local/HeroImageIsDefined-2/source.html`)
     );
   });
   it(`${HeroImageIsDefined.name} - data-hero missing`, async () => {
     return assertWarn(
-      runLocalTest(
-        HeroImageIsDefined,
-        `${__dirname}/local/HeroImageIsDefined-3/source.html`
-      )
+      runLocalTest(HeroImageIsDefined, `${__dirname}/local/HeroImageIsDefined-3/source.html`)
     );
   });
 });
@@ -404,19 +314,13 @@ describe(HeroImageIsDefined.name, () => {
 describe(IsTransformedAmp.name, () => {
   it(`${IsTransformedAmp.name} - Transformed AMP detected`, async () => {
     return assertPass(
-      runLocalTest(
-        IsTransformedAmp,
-        `${__dirname}/local/IsTransformedAmp-1/source.html`
-      )
+      runLocalTest(IsTransformedAmp, `${__dirname}/local/IsTransformedAmp-1/source.html`)
     );
   });
 
   it(`${IsTransformedAmp.name} - No transformed AMP detected`, async () => {
     return assertWarn(
-      runLocalTest(
-        IsTransformedAmp,
-        `${__dirname}/local/IsTransformedAmp-2/source.html`
-      )
+      runLocalTest(IsTransformedAmp, `${__dirname}/local/IsTransformedAmp-2/source.html`)
     );
   });
 });
@@ -424,19 +328,13 @@ describe(IsTransformedAmp.name, () => {
 describe(MetaCharsetIsFirst.name, () => {
   it(`${MetaCharsetIsFirst.name} - <meta charset> is first`, async () => {
     return assertPass(
-      runLocalTest(
-        MetaCharsetIsFirst,
-        `${__dirname}/local/MetaCharsetIsFirst-1/source.html`
-      )
+      runLocalTest(MetaCharsetIsFirst, `${__dirname}/local/MetaCharsetIsFirst-1/source.html`)
     );
   });
 
   it(`${MetaCharsetIsFirst.name} - <meta charset> missing`, async () => {
     return assertFail(
-      runLocalTest(
-        MetaCharsetIsFirst,
-        `${__dirname}/local/MetaCharsetIsFirst-2/source.html`
-      )
+      runLocalTest(MetaCharsetIsFirst, `${__dirname}/local/MetaCharsetIsFirst-2/source.html`)
     );
   });
 });
@@ -444,19 +342,13 @@ describe(MetaCharsetIsFirst.name, () => {
 describe(ModuleRuntimeUsed.name, () => {
   it(`${ModuleRuntimeUsed.name} - Module runtime script found`, async () => {
     return assertPass(
-      runLocalTest(
-        ModuleRuntimeUsed,
-        `${__dirname}/local/ModuleRuntimeUsed-1/source.html`
-      )
+      runLocalTest(ModuleRuntimeUsed, `${__dirname}/local/ModuleRuntimeUsed-1/source.html`)
     );
   });
 
   it(`${ModuleRuntimeUsed.name} - Module runtime script not found`, async () => {
     return assertWarn(
-      runLocalTest(
-        ModuleRuntimeUsed,
-        `${__dirname}/local/ModuleRuntimeUsed-2/source.html`
-      )
+      runLocalTest(ModuleRuntimeUsed, `${__dirname}/local/ModuleRuntimeUsed-2/source.html`)
     );
   });
 });
@@ -464,28 +356,19 @@ describe(ModuleRuntimeUsed.name, () => {
 describe(RuntimeIsPreloaded.name, () => {
   it(`${RuntimeIsPreloaded.name} - <link rel="preload"> is absent`, async () => {
     return assertWarn(
-      runLocalTest(
-        RuntimeIsPreloaded,
-        `${__dirname}/local/RuntimeIsPreloaded-1/source.html`
-      )
+      runLocalTest(RuntimeIsPreloaded, `${__dirname}/local/RuntimeIsPreloaded-1/source.html`)
     );
   });
 
   it(`${RuntimeIsPreloaded.name} - <link rel="preload"> is present`, async () => {
     return assertPass(
-      runLocalTest(
-        RuntimeIsPreloaded,
-        `${__dirname}/local/RuntimeIsPreloaded-2/source.html`
-      )
+      runLocalTest(RuntimeIsPreloaded, `${__dirname}/local/RuntimeIsPreloaded-2/source.html`)
     );
   });
 
   it(`${RuntimeIsPreloaded.name} - <link rel="modulepreload"> is present`, async () => {
     return assertPass(
-      runLocalTest(
-        RuntimeIsPreloaded,
-        `${__dirname}/local/RuntimeIsPreloaded-3/source.html`
-      )
+      runLocalTest(RuntimeIsPreloaded, `${__dirname}/local/RuntimeIsPreloaded-3/source.html`)
     );
   });
 });
@@ -493,19 +376,13 @@ describe(RuntimeIsPreloaded.name, () => {
 describe(SchemaMetadataIsNews.name, () => {
   it(`${SchemaMetadataIsNews.name} - schema type is NewsArticle`, async () => {
     return assertPass(
-      runLocalTest(
-        SchemaMetadataIsNews,
-        `${__dirname}/local/SchemaMetadataIsNews-1/source.html`
-      )
+      runLocalTest(SchemaMetadataIsNews, `${__dirname}/local/SchemaMetadataIsNews-1/source.html`)
     );
   });
 
   it(`${SchemaMetadataIsNews.name} - schema type is not NewsArticle`, async () => {
     return assertWarn(
-      runLocalTest(
-        SchemaMetadataIsNews,
-        `${__dirname}/local/SchemaMetadataIsNews-2/source.html`
-      )
+      runLocalTest(SchemaMetadataIsNews, `${__dirname}/local/SchemaMetadataIsNews-2/source.html`)
     );
   });
 });
@@ -513,19 +390,13 @@ describe(SchemaMetadataIsNews.name, () => {
 describe(StoryRuntimeIsV1.name, () => {
   it(`${StoryRuntimeIsV1.name} - runtime is v1`, async () => {
     return assertPass(
-      runLocalTest(
-        StoryRuntimeIsV1,
-        `${__dirname}/local/StoryRuntimeIsV1-1/source.html`
-      )
+      runLocalTest(StoryRuntimeIsV1, `${__dirname}/local/StoryRuntimeIsV1-1/source.html`)
     );
   });
 
   it(`${StoryRuntimeIsV1.name} - runtime is not v1`, async () => {
     return assertFail(
-      runLocalTest(
-        StoryRuntimeIsV1,
-        `${__dirname}/local/StoryRuntimeIsV1-2/source.html`
-      )
+      runLocalTest(StoryRuntimeIsV1, `${__dirname}/local/StoryRuntimeIsV1-2/source.html`)
     );
   });
 });
@@ -533,28 +404,19 @@ describe(StoryRuntimeIsV1.name, () => {
 describe(BookendExists.name, () => {
   it(`${BookendExists.name} - external bookend data`, async () => {
     return assertPass(
-      runLocalTest(
-        BookendExists,
-        `${__dirname}/local/BookendExists-1/source.html`
-      )
+      runLocalTest(BookendExists, `${__dirname}/local/BookendExists-1/source.html`)
     );
   });
 
   it(`${BookendExists.name} - inline bookend data`, async () => {
     return assertPass(
-      runLocalTest(
-        BookendExists,
-        `${__dirname}/local/BookendExists-2/source.html`
-      )
+      runLocalTest(BookendExists, `${__dirname}/local/BookendExists-2/source.html`)
     );
   });
 
   it(`${BookendExists.name} - no bookend`, async () => {
     return assertWarn(
-      runLocalTest(
-        BookendExists,
-        `${__dirname}/local/BookendExists-3/source.html`
-      )
+      runLocalTest(BookendExists, `${__dirname}/local/BookendExists-3/source.html`)
     );
   });
 });
@@ -591,19 +453,13 @@ describe(MetadataIncludesOGImageSrc.name, () => {
 describe(ImagesHaveAltText.name, () => {
   it(`${ImagesHaveAltText.name} - All <amp-img> have alt text`, async () => {
     return assertPass(
-      runLocalTest(
-        ImagesHaveAltText,
-        `${__dirname}/local/ImagesHaveAltText-1/source.html`
-      )
+      runLocalTest(ImagesHaveAltText, `${__dirname}/local/ImagesHaveAltText-1/source.html`)
     );
   });
 
   it(`${ImagesHaveAltText.name} - At least one <amp-img> is missing alt text`, async () => {
     return assertWarn(
-      runLocalTest(
-        ImagesHaveAltText,
-        `${__dirname}/local/ImagesHaveAltText-2/source.html`
-      )
+      runLocalTest(ImagesHaveAltText, `${__dirname}/local/ImagesHaveAltText-2/source.html`)
     );
   });
 });
@@ -611,19 +467,13 @@ describe(ImagesHaveAltText.name, () => {
 describe(VideosHaveAltText.name, () => {
   it(`${VideosHaveAltText.name} - All <amp-video> have alt text`, async () => {
     return assertPass(
-      runLocalTest(
-        VideosHaveAltText,
-        `${__dirname}/local/VideosHaveAltText-1/source.html`
-      )
+      runLocalTest(VideosHaveAltText, `${__dirname}/local/VideosHaveAltText-1/source.html`)
     );
   });
 
   it(`${VideosHaveAltText.name} - At least one <amp-video> is missing alt text`, async () => {
     return assertWarn(
-      runLocalTest(
-        VideosHaveAltText,
-        `${__dirname}/local/VideosHaveAltText-2/source.html`
-      )
+      runLocalTest(VideosHaveAltText, `${__dirname}/local/VideosHaveAltText-2/source.html`)
     );
   });
 });
@@ -631,19 +481,13 @@ describe(VideosHaveAltText.name, () => {
 describe(VideosAreSubtitled.name, () => {
   it(`${VideosAreSubtitled.name} - All <amp-video> have subtitles`, async () => {
     return assertPass(
-      runLocalTest(
-        VideosAreSubtitled,
-        `${__dirname}/local/VideosAreSubtitled-1/source.html`
-      )
+      runLocalTest(VideosAreSubtitled, `${__dirname}/local/VideosAreSubtitled-1/source.html`)
     );
   });
 
   it(`${VideosAreSubtitled.name} - One or more <amp-video> are missing subtitles`, async () => {
     return assertWarn(
-      runLocalTest(
-        VideosAreSubtitled,
-        `${__dirname}/local/VideosAreSubtitled-2/source.html`
-      )
+      runLocalTest(VideosAreSubtitled, `${__dirname}/local/VideosAreSubtitled-2/source.html`)
     );
   });
 });

--- a/packages/linter/tests/network.test.ts
+++ b/packages/linter/tests/network.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { restore as nockRestore } from "nock";
-jest.mock("../src/caches");
+import {readFileSync} from 'fs';
+import {restore as nockRestore} from 'nock';
+jest.mock('../src/caches');
 import {
   withFixture,
   assertMatch,
@@ -8,26 +8,24 @@ import {
   assertPass,
   assertFail,
   assertFnList,
-} from "./lib";
-import { StoryMetadataThumbnailsAreOk } from "../src/rules/StoryMetadataThumbnailsAreOk";
-import { Result, Status } from "../src";
-import { LinkRelCanonicalIsOk } from "../src/rules/LinkRelCanonicalIsOk";
-import { AmpVideoIsSmall } from "../src/rules/AmpVideoIsSmall";
-import { StoryMetadataIsV1 } from "../src/rules/StoryMetadataIsV1";
-import { AmpImgHeightWidthIsOk } from "../src/rules/AmpImgHeightWidthIsOk";
-import { EndpointsAreAccessibleFromOrigin } from "../src/rules/EndpointsAreAccessibleFromOrigin";
-import { EndpointsAreAccessibleFromCache } from "../src/rules/EndpointsAreAccessibleFromCache";
-import { SxgVaryOnAcceptAct } from "../src/rules/SxgVaryOnAcceptAct";
-import { SxgContentNegotiationIsOk } from "../src/rules/SxgContentNegotiationIsOk";
-import { SxgAmppkgIsForwarded } from "../src/rules/SxgAmppkgIsForwarded";
-import { IsValid } from "../src/rules/IsValid";
-import { caches } from "../src/caches";
+} from './lib';
+import {StoryMetadataThumbnailsAreOk} from '../src/rules/StoryMetadataThumbnailsAreOk';
+import {Result, Status} from '../src';
+import {LinkRelCanonicalIsOk} from '../src/rules/LinkRelCanonicalIsOk';
+import {AmpVideoIsSmall} from '../src/rules/AmpVideoIsSmall';
+import {StoryMetadataIsV1} from '../src/rules/StoryMetadataIsV1';
+import {AmpImgHeightWidthIsOk} from '../src/rules/AmpImgHeightWidthIsOk';
+import {EndpointsAreAccessibleFromOrigin} from '../src/rules/EndpointsAreAccessibleFromOrigin';
+import {EndpointsAreAccessibleFromCache} from '../src/rules/EndpointsAreAccessibleFromCache';
+import {SxgVaryOnAcceptAct} from '../src/rules/SxgVaryOnAcceptAct';
+import {SxgContentNegotiationIsOk} from '../src/rules/SxgContentNegotiationIsOk';
+import {SxgAmppkgIsForwarded} from '../src/rules/SxgAmppkgIsForwarded';
+import {IsValid} from '../src/rules/IsValid';
+import {caches} from '../src/caches';
 
 beforeAll(() => {
   (caches as jest.Mock).mockReturnValue(
-    Promise.resolve(
-      JSON.parse(readFileSync(`${__dirname}/caches.json`).toString()).caches
-    )
+    Promise.resolve(JSON.parse(readFileSync(`${__dirname}/caches.json`).toString()).caches)
   );
 });
 
@@ -41,11 +39,11 @@ afterAll(() => {
 
 describe(StoryMetadataThumbnailsAreOk.name, () => {
   it(`${StoryMetadataThumbnailsAreOk.name} - poster-portrait-src is too small`, () => {
-    return withFixture("thumbnails1", () =>
+    return withFixture('thumbnails1', () =>
       assertFnList(
         runNetworkTest(
           StoryMetadataThumbnailsAreOk,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         ),
         (actual: Result[]) => {
           let fails = 0;
@@ -55,42 +53,34 @@ describe(StoryMetadataThumbnailsAreOk.name, () => {
             }
           });
 
-          return fails === 1
-            ? ""
-            : `expected one error, got ${JSON.stringify(actual)}`;
+          return fails === 1 ? '' : `expected one error, got ${JSON.stringify(actual)}`;
         }
       )
     );
   });
 
   it(`${StoryMetadataThumbnailsAreOk.name} - publisher-logo-src missing`, () => {
-    return withFixture("thumbnails2", () =>
+    return withFixture('thumbnails2', () =>
       assertMatch(
-        runNetworkTest(
-          StoryMetadataThumbnailsAreOk,
-          "https://regular-biology.glitch.me/"
-        ),
-        "publisher-logo-src"
+        runNetworkTest(StoryMetadataThumbnailsAreOk, 'https://regular-biology.glitch.me/'),
+        'publisher-logo-src'
       )
     );
   });
 
   it(`${StoryMetadataThumbnailsAreOk.name} - poster-portrait-src not found`, () => {
-    return withFixture("thumbnails3", () =>
+    return withFixture('thumbnails3', () =>
       assertMatch(
-        runNetworkTest(StoryMetadataThumbnailsAreOk, "http://localhost:5000/"),
-        "file not found"
+        runNetworkTest(StoryMetadataThumbnailsAreOk, 'http://localhost:5000/'),
+        'file not found'
       )
     );
   });
 
   it(`${StoryMetadataThumbnailsAreOk.name} - publisher-logo-src is webp`, () => {
-    return withFixture("thumbnails4", () =>
+    return withFixture('thumbnails4', () =>
       assertFnList(
-        runNetworkTest(
-          StoryMetadataThumbnailsAreOk,
-          "https://fantastic-lemon-asterisk.glitch.me/"
-        ),
+        runNetworkTest(StoryMetadataThumbnailsAreOk, 'https://fantastic-lemon-asterisk.glitch.me/'),
         (actual: Result[]) => {
           let fails = 0;
           actual.forEach((result) => {
@@ -99,21 +89,16 @@ describe(StoryMetadataThumbnailsAreOk.name, () => {
             }
           });
 
-          return fails === 0
-            ? ""
-            : `expected no errors, got ${JSON.stringify(actual)}`;
+          return fails === 0 ? '' : `expected no errors, got ${JSON.stringify(actual)}`;
         }
       )
     );
   });
 
   it(`${StoryMetadataThumbnailsAreOk.name} - poster-portrait-src is correct size`, () => {
-    return withFixture("thumbnails5", () =>
+    return withFixture('thumbnails5', () =>
       assertFnList(
-        runNetworkTest(
-          StoryMetadataThumbnailsAreOk,
-          "https://fantastic-lemon-asterisk.glitch.me/"
-        ),
+        runNetworkTest(StoryMetadataThumbnailsAreOk, 'https://fantastic-lemon-asterisk.glitch.me/'),
         (actual: Result[]) => {
           let fails = 0;
           actual.forEach((result) => {
@@ -122,9 +107,7 @@ describe(StoryMetadataThumbnailsAreOk.name, () => {
             }
           });
 
-          return fails === 0
-            ? ""
-            : `expected no errors, got ${JSON.stringify(actual)}`;
+          return fails === 0 ? '' : `expected no errors, got ${JSON.stringify(actual)}`;
         }
       )
     );
@@ -133,95 +116,69 @@ describe(StoryMetadataThumbnailsAreOk.name, () => {
 
 describe(IsValid.name, () => {
   it(`${IsValid.name} - valid`, () => {
-    return withFixture("testvalidity1", () =>
-      assertPass(runNetworkTest(IsValid, "https://www.ampproject.org/"))
+    return withFixture('testvalidity1', () =>
+      assertPass(runNetworkTest(IsValid, 'https://www.ampproject.org/'))
     );
   });
 
   it(`${IsValid.name} - not valid`, () => {
-    return withFixture("testvalidity2", async () =>
-      assertFail(
-        runNetworkTest(IsValid, "https://precious-sturgeon.glitch.me/")
-      )
+    return withFixture('testvalidity2', async () =>
+      assertFail(runNetworkTest(IsValid, 'https://precious-sturgeon.glitch.me/'))
     );
   });
 
   it(`${IsValid.name} - valid with svg`, () => {
-    return withFixture("testvalidity3", () =>
-      assertPass(runNetworkTest(IsValid, "https://amp.dev/index.amp.html"))
+    return withFixture('testvalidity3', () =>
+      assertPass(runNetworkTest(IsValid, 'https://amp.dev/index.amp.html'))
     );
   });
 });
 
 describe(LinkRelCanonicalIsOk.name, () => {
   it(`${LinkRelCanonicalIsOk.name} - canonical`, () => {
-    return withFixture("testcanonical1", () =>
-      assertPass(
-        runNetworkTest(
-          LinkRelCanonicalIsOk,
-          "https://regular-biology.glitch.me/"
-        )
-      )
+    return withFixture('testcanonical1', () =>
+      assertPass(runNetworkTest(LinkRelCanonicalIsOk, 'https://regular-biology.glitch.me/'))
     );
   });
 
   it(`${LinkRelCanonicalIsOk.name} - not canonical`, () => {
-    return withFixture("testcanonical2", () =>
-      assertFail(
-        runNetworkTest(
-          LinkRelCanonicalIsOk,
-          "https://copper-cupboard.glitch.me/"
-        )
-      )
+    return withFixture('testcanonical2', () =>
+      assertFail(runNetworkTest(LinkRelCanonicalIsOk, 'https://copper-cupboard.glitch.me/'))
     );
   });
 
   it(`${LinkRelCanonicalIsOk.name} - relative`, () => {
-    return withFixture("testcanonical3", () =>
-      assertPass(
-        runNetworkTest(
-          LinkRelCanonicalIsOk,
-          "https://regular-biology.glitch.me/"
-        )
-      )
+    return withFixture('testcanonical3', () =>
+      assertPass(runNetworkTest(LinkRelCanonicalIsOk, 'https://regular-biology.glitch.me/'))
     );
   });
 
   it(`${LinkRelCanonicalIsOk.name} - not AMP Story`, () => {
-    return withFixture("testcanonical4", () =>
-      assertPass(
-        runNetworkTest(
-          LinkRelCanonicalIsOk,
-          "https://bejewled-tachometer.glitch.me/"
-        )
-      )
+    return withFixture('testcanonical4', () =>
+      assertPass(runNetworkTest(LinkRelCanonicalIsOk, 'https://bejewled-tachometer.glitch.me/'))
     );
   });
 });
 
 describe(AmpVideoIsSmall.name, () => {
   it(`${AmpVideoIsSmall.name} - too big`, () => {
-    return withFixture("testvideosize1", () =>
-      assertFail(
-        runNetworkTest(AmpVideoIsSmall, "https://regular-biology.glitch.me/")
-      )
+    return withFixture('testvideosize1', () =>
+      assertFail(runNetworkTest(AmpVideoIsSmall, 'https://regular-biology.glitch.me/'))
     );
   });
 
   it(`${AmpVideoIsSmall.name} - good size #1`, () => {
-    return withFixture("testvideosize2", () =>
-      assertPass(
-        runNetworkTest(AmpVideoIsSmall, "https://regular-biology.glitch.me/")
-      )
+    return withFixture('testvideosize2', () =>
+      assertPass(runNetworkTest(AmpVideoIsSmall, 'https://regular-biology.glitch.me/'))
     );
   });
 
   it(`${AmpVideoIsSmall.name} - good size #2`, () => {
-    return withFixture("testvideosize3", () =>
+    return withFixture('testvideosize3', () =>
       assertPass(
         runNetworkTest(
           AmpVideoIsSmall,
-          "https://ampbyexample.com/stories/features/media/preview/embed/"
+          'https://ampbyexample.com/stories/features/media/preview/embed/'
         )
       )
     );
@@ -230,46 +187,46 @@ describe(AmpVideoIsSmall.name, () => {
 
 describe(EndpointsAreAccessibleFromOrigin.name, () => {
   it(`${EndpointsAreAccessibleFromOrigin.name} - configured correctly`, () => {
-    return withFixture("bookendsameorigin1", () =>
+    return withFixture('bookendsameorigin1', () =>
       assertPass(
         runNetworkTest(
           EndpointsAreAccessibleFromOrigin,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         )
       )
     );
   });
 
   it(`${EndpointsAreAccessibleFromOrigin.name} - bookend not application/json`, () => {
-    return withFixture("bookendsameorigin2", () =>
+    return withFixture('bookendsameorigin2', () =>
       assertMatch(
         runNetworkTest(
           EndpointsAreAccessibleFromOrigin,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         ),
-        "application/json"
+        'application/json'
       )
     );
   });
 
   it(`${EndpointsAreAccessibleFromOrigin.name} - bookend not JSON`, () => {
-    return withFixture("bookendsameorigin3", () =>
+    return withFixture('bookendsameorigin3', () =>
       assertMatch(
         runNetworkTest(
           EndpointsAreAccessibleFromOrigin,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         ),
-        "JSON"
+        'JSON'
       )
     );
   });
 
   it(`${EndpointsAreAccessibleFromOrigin.name} - v0 AMP Story - configured correctly`, () => {
-    return withFixture("bookendsameorgin4", () =>
+    return withFixture('bookendsameorgin4', () =>
       assertPass(
         runNetworkTest(
           EndpointsAreAccessibleFromOrigin,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         )
       )
     );
@@ -278,24 +235,24 @@ describe(EndpointsAreAccessibleFromOrigin.name, () => {
 
 describe(EndpointsAreAccessibleFromCache.name, () => {
   it(`${EndpointsAreAccessibleFromCache.name} - configured correctly`, () => {
-    return withFixture("bookendcache1", () =>
+    return withFixture('bookendcache1', () =>
       assertPass(
         runNetworkTest(
           EndpointsAreAccessibleFromCache,
-          "https://preview.amp.dev/documentation/examples/introduction/stories_in_amp/"
+          'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp/'
         )
       )
     );
   });
 
   it(`${EndpointsAreAccessibleFromCache.name} - incorrect headers`, () => {
-    return withFixture("bookendcache2", () =>
+    return withFixture('bookendcache2', () =>
       assertMatch(
         runNetworkTest(
           EndpointsAreAccessibleFromCache,
-          "https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/"
+          'https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/'
         ),
-        "access-control-allow-origin"
+        'access-control-allow-origin'
       )
     );
   });
@@ -303,24 +260,24 @@ describe(EndpointsAreAccessibleFromCache.name, () => {
 
 describe(StoryMetadataIsV1.name, () => {
   it(`${StoryMetadataIsV1.name} - valid metadata`, () => {
-    return withFixture("ampstoryv1metadata1", () =>
+    return withFixture('ampstoryv1metadata1', () =>
       assertPass(
         runNetworkTest(
           StoryMetadataIsV1,
-          "https://ithinkihaveacat.github.io/hello-world-amp-story/"
+          'https://ithinkihaveacat.github.io/hello-world-amp-story/'
         )
       )
     );
   });
 
   it(`${StoryMetadataIsV1.name} - invalid metadata`, () => {
-    return withFixture("ampstoryv1metadata2", () =>
+    return withFixture('ampstoryv1metadata2', () =>
       assertMatch(
         runNetworkTest(
           StoryMetadataIsV1,
-          "https://ithinkihaveacat-hello-world-amp-story-7.glitch.me/"
+          'https://ithinkihaveacat-hello-world-amp-story-7.glitch.me/'
         ),
-        "publisher-logo-src"
+        'publisher-logo-src'
       )
     );
   });
@@ -328,141 +285,109 @@ describe(StoryMetadataIsV1.name, () => {
 
 describe(AmpImgHeightWidthIsOk.name, () => {
   it(`${AmpImgHeightWidthIsOk.name} - height/width are incorrect #1`, () => {
-    return withFixture("ampimg1", () =>
+    return withFixture('ampimg1', () =>
       assertFnList(
-        runNetworkTest(
-          AmpImgHeightWidthIsOk,
-          "https://ampbyexample.com/components/amp-img/"
-        ),
+        runNetworkTest(AmpImgHeightWidthIsOk, 'https://ampbyexample.com/components/amp-img/'),
         (res) => {
           if (res.length !== 3) {
-            return "expected 3 failures";
+            return 'expected 3 failures';
           }
           const message = res[1].message;
-          if (typeof message !== "string" || !message.match("does-not-exist")) {
-            return "does-not-exist.jpg should be a 404";
+          if (typeof message !== 'string' || !message.match('does-not-exist')) {
+            return 'does-not-exist.jpg should be a 404';
           }
-          return "";
+          return '';
         }
       )
     );
   });
 
   it(`${AmpImgHeightWidthIsOk.name} - height/width are incorrect #2`, () => {
-    return withFixture("ampimg2", () =>
+    return withFixture('ampimg2', () =>
       assertFnList(
         runNetworkTest(
           AmpImgHeightWidthIsOk,
-          "https://www.ampproject.org/docs/reference/components/amp-story"
+          'https://www.ampproject.org/docs/reference/components/amp-story'
         ),
         (res) => {
           if (res.length !== 6) {
-            return "expected 6 failures";
+            return 'expected 6 failures';
           }
           const message1 = res[0].message;
-          if (
-            typeof message1 !== "string" ||
-            !message1.match("amp-story-tag-hierarchy")
-          ) {
-            return "amp-story-tag-hierarchy.png is wrong ratio";
+          if (typeof message1 !== 'string' || !message1.match('amp-story-tag-hierarchy')) {
+            return 'amp-story-tag-hierarchy.png is wrong ratio';
           }
           const message2 = res[5].message;
-          if (
-            typeof message2 !== "string" ||
-            !message2.match("layers-layer-3")
-          ) {
-            return "layers-layer-3.jpg is too big";
+          if (typeof message2 !== 'string' || !message2.match('layers-layer-3')) {
+            return 'layers-layer-3.jpg is too big';
           }
-          return "";
+          return '';
         }
       )
     );
   });
 
   it(`${AmpImgHeightWidthIsOk.name} - height/width are correct`, () => {
-    return withFixture("ampimg3", () =>
+    return withFixture('ampimg3', () =>
       assertFnList(
-        runNetworkTest(
-          AmpImgHeightWidthIsOk,
-          "https://ampbyexample.com/introduction/hello_world/"
-        ),
+        runNetworkTest(AmpImgHeightWidthIsOk, 'https://ampbyexample.com/introduction/hello_world/'),
         (res) => {
-          return res.length === 0
-            ? ""
-            : `expected 0 failures, got ${JSON.stringify(res)}`;
+          return res.length === 0 ? '' : `expected 0 failures, got ${JSON.stringify(res)}`;
         }
       )
     );
   });
 
   it(`${AmpImgHeightWidthIsOk.name} - height/width are incorrect, but ignored`, () => {
-    return withFixture("ampimg4", () =>
+    return withFixture('ampimg4', () =>
       assertFnList(
-        runNetworkTest(AmpImgHeightWidthIsOk, "https://pyrite-coil.glitch.me"),
+        runNetworkTest(AmpImgHeightWidthIsOk, 'https://pyrite-coil.glitch.me'),
         (res) => {
-          return res.length === 0
-            ? ""
-            : `expected 0 failures, got ${JSON.stringify(res)}`;
+          return res.length === 0 ? '' : `expected 0 failures, got ${JSON.stringify(res)}`;
         }
       )
     );
   });
 
   it(`${AmpImgHeightWidthIsOk.name} - height/width are correct`, () => {
-    return withFixture("ampimg5", () =>
+    return withFixture('ampimg5', () =>
       assertFnList(
-        runNetworkTest(
-          AmpImgHeightWidthIsOk,
-          "https://charming-pirate.glitch.me/"
-        ),
+        runNetworkTest(AmpImgHeightWidthIsOk, 'https://charming-pirate.glitch.me/'),
         (res) => {
-          return res.length === 0
-            ? ""
-            : `expected 0 failures, got ${JSON.stringify(res)}`;
+          return res.length === 0 ? '' : `expected 0 failures, got ${JSON.stringify(res)}`;
         }
       )
     );
   });
 });
 
-describe("CORS", () => {
+describe('CORS', () => {
   describe(EndpointsAreAccessibleFromOrigin.name, () => {
     it(`${EndpointsAreAccessibleFromOrigin.name} - all headers correct`, () => {
-      return withFixture("cors1", () =>
+      return withFixture('cors1', () =>
         assertFnList(
-          runNetworkTest(
-            EndpointsAreAccessibleFromOrigin,
-            "https://swift-track.glitch.me/"
-          ),
+          runNetworkTest(EndpointsAreAccessibleFromOrigin, 'https://swift-track.glitch.me/'),
           (res) => {
-            return res.length === 0
-              ? ""
-              : `expected 0 failures, got ${JSON.stringify(res)}`;
+            return res.length === 0 ? '' : `expected 0 failures, got ${JSON.stringify(res)}`;
           }
         )
       );
     });
 
     it(`${EndpointsAreAccessibleFromOrigin.name} - endpoint is 404`, () => {
-      return withFixture("cors2", () =>
+      return withFixture('cors2', () =>
         assertMatch(
-          runNetworkTest(
-            EndpointsAreAccessibleFromOrigin,
-            "https://swift-track.glitch.me/"
-          ),
-          "404"
+          runNetworkTest(EndpointsAreAccessibleFromOrigin, 'https://swift-track.glitch.me/'),
+          '404'
         )
       );
     });
 
     it(`${EndpointsAreAccessibleFromOrigin.name} - endpoint not application/json`, () => {
-      return withFixture("cors3", () =>
+      return withFixture('cors3', () =>
         assertMatch(
-          runNetworkTest(
-            EndpointsAreAccessibleFromOrigin,
-            "https://swift-track.glitch.me/"
-          ),
-          "application/json"
+          runNetworkTest(EndpointsAreAccessibleFromOrigin, 'https://swift-track.glitch.me/'),
+          'application/json'
         )
       );
     });
@@ -470,12 +395,9 @@ describe("CORS", () => {
 
   describe(EndpointsAreAccessibleFromCache.name, () => {
     it(`${EndpointsAreAccessibleFromCache.name} - all headers correct`, () => {
-      return withFixture("cors4", () =>
+      return withFixture('cors4', () =>
         assertPass(
-          runNetworkTest(
-            EndpointsAreAccessibleFromCache,
-            "https://swift-track.glitch.me/"
-          )
+          runNetworkTest(EndpointsAreAccessibleFromCache, 'https://swift-track.glitch.me/')
         )
       );
     });
@@ -484,80 +406,51 @@ describe("CORS", () => {
 
 describe(SxgVaryOnAcceptAct.name, () => {
   it(`${SxgVaryOnAcceptAct.name} - vary header not returned`, () => {
-    return withFixture("sxgvary1", () => {
-      return assertFail(
-        runNetworkTest(
-          SxgVaryOnAcceptAct,
-          "https://boundless-stealer.glitch.me/"
-        )
-      );
+    return withFixture('sxgvary1', () => {
+      return assertFail(runNetworkTest(SxgVaryOnAcceptAct, 'https://boundless-stealer.glitch.me/'));
     });
   });
 
   it(`${SxgVaryOnAcceptAct.name} - no vary on amp-cache-transform`, () => {
-    return withFixture("sxgvary2", () => {
-      return assertFail(
-        runNetworkTest(
-          SxgVaryOnAcceptAct,
-          "https://boundless-stealer.glitch.me/"
-        )
-      );
+    return withFixture('sxgvary2', () => {
+      return assertFail(runNetworkTest(SxgVaryOnAcceptAct, 'https://boundless-stealer.glitch.me/'));
     });
   });
 
   it(`${SxgVaryOnAcceptAct.name} - no vary on accept`, () => {
-    return withFixture("sxgvary3", () => {
-      return assertFail(
-        runNetworkTest(
-          SxgVaryOnAcceptAct,
-          "https://boundless-stealer.glitch.me/"
-        )
-      );
+    return withFixture('sxgvary3', () => {
+      return assertFail(runNetworkTest(SxgVaryOnAcceptAct, 'https://boundless-stealer.glitch.me/'));
     });
   });
 
   it(`${SxgVaryOnAcceptAct.name} - vary on accept and amp-cache-transform`, () => {
-    return withFixture("sxgvary4", () => {
-      return assertPass(
-        runNetworkTest(
-          SxgVaryOnAcceptAct,
-          "https://boundless-stealer.glitch.me/"
-        )
-      );
+    return withFixture('sxgvary4', () => {
+      return assertPass(runNetworkTest(SxgVaryOnAcceptAct, 'https://boundless-stealer.glitch.me/'));
     });
   });
 });
 
 describe(SxgContentNegotiationIsOk.name, () => {
   it(`${SxgContentNegotiationIsOk.name} - application/signed-exchange supported`, () => {
-    return withFixture("sxgconneg1", () => {
+    return withFixture('sxgconneg1', () => {
       return assertPass(
-        runNetworkTest(
-          SxgContentNegotiationIsOk,
-          "https://azei-package-test.com/"
-        )
+        runNetworkTest(SxgContentNegotiationIsOk, 'https://azei-package-test.com/')
       );
     });
   });
 
   it(`${SxgContentNegotiationIsOk.name} - application/signed-exchange not supported`, () => {
-    return withFixture("sxgconneg2", () => {
+    return withFixture('sxgconneg2', () => {
       return assertFail(
-        runNetworkTest(
-          SxgContentNegotiationIsOk,
-          "https://boundless-stealer.glitch.me/"
-        )
+        runNetworkTest(SxgContentNegotiationIsOk, 'https://boundless-stealer.glitch.me/')
       );
     });
   });
 
   it(`${SxgContentNegotiationIsOk.name} - application/signed-exchange incorrectly supported`, () => {
-    return withFixture("sxgconneg3", () => {
+    return withFixture('sxgconneg3', () => {
       return assertFail(
-        runNetworkTest(
-          SxgContentNegotiationIsOk,
-          "https://azei-package-test.com/"
-        )
+        runNetworkTest(SxgContentNegotiationIsOk, 'https://azei-package-test.com/')
       );
     });
   });
@@ -565,29 +458,22 @@ describe(SxgContentNegotiationIsOk.name, () => {
 
 describe(SxgAmppkgIsForwarded.name, () => {
   it(`${SxgAmppkgIsForwarded.name} - /amppkg/ is forwarded`, () => {
-    return withFixture("sxgamppkg2", () => {
-      return assertPass(
-        runNetworkTest(SxgAmppkgIsForwarded, "https://azei-package-test.com/")
-      );
+    return withFixture('sxgamppkg2', () => {
+      return assertPass(runNetworkTest(SxgAmppkgIsForwarded, 'https://azei-package-test.com/'));
     });
   });
 
   it(`${SxgAmppkgIsForwarded.name} - /amppkg/ not forwarded (404)`, () => {
-    return withFixture("sxgamppkg1", () => {
+    return withFixture('sxgamppkg1', () => {
       return assertFail(
-        runNetworkTest(
-          SxgAmppkgIsForwarded,
-          "https://boundless-stealer.glitch.me/"
-        )
+        runNetworkTest(SxgAmppkgIsForwarded, 'https://boundless-stealer.glitch.me/')
       );
     });
   });
 
   it(`${SxgAmppkgIsForwarded.name} - /amppkg/ not forwarded (wrong content-type)`, () => {
-    return withFixture("sxgamppkg3", () => {
-      return assertFail(
-        runNetworkTest(SxgAmppkgIsForwarded, "https://azei-package-test.com/")
-      );
+    return withFixture('sxgamppkg3', () => {
+      return assertFail(runNetworkTest(SxgAmppkgIsForwarded, 'https://azei-package-test.com/'));
     });
   });
 });


### PR DESCRIPTION
**summary**
- configures `npm run format` to respect the local configuration file. Also quotes the `**/*.{js,ts}` to force prettier to handle the globs instead of shell expansion. I was seeing an issue where it was too many files for my shell to process.
- runs `npm run format`