### PR TITLE
cf worker scripts: turn kv cache back on

### DIFF
--- a/packages/cloudflare-optimizer-scripts/demo/config.json
+++ b/packages/cloudflare-optimizer-scripts/demo/config.json
@@ -3,7 +3,7 @@
     "origin": "cf-optimizer-demo.web.app",
     "worker": "optimizer-demo.ampdev.workers.dev"
   },
-  "enableKVCache": false,
+  "enableKVCache": true,
   "enableCloudflareImageOptimization": false,
   "optimizer": {
     "maxHeroImageCount": 5


### PR DESCRIPTION
mistakenly left if `off` in the demo after testing