### PR TITLE
Enable OptimizeAmpBind transformer by default

### DIFF
--- a/packages/optimizer/README.md
+++ b/packages/optimizer/README.md
@@ -231,7 +231,7 @@ Enables a considerably faster scanning method in `amp-bind`, by injecting a `i-a
 
 - name: `optimizeAmpBind`
 - valid options: `[true|false]`
-- default: `false`
+- default: `true`
 - used by: [OptimizeAmpBind](lib/transformers/OptimizeAmpBind.js)
 
 #### `optimizeHeroImages`

--- a/packages/optimizer/lib/transformers/OptimizeAmpBind.js
+++ b/packages/optimizer/lib/transformers/OptimizeAmpBind.js
@@ -24,7 +24,7 @@ class OptimizeAmpBind {
   constructor(config) {
     this.log_ = config.log.tag('OptimizeAmpBind');
 
-    this.enabled_ = !!config.optimizeAmpBind;
+    this.enabled_ = config.optimizeAmpBind !== false;
     if (!this.enabled_) {
       this.log_.debug('disabled');
     }


### PR DESCRIPTION
As discussed in https://github.com/ampproject/amp-toolbox/pull/1147/files#r582707679 and given the required changes in the validator and runtime are now live, the `OptimizeAmpBind` transformer should be enabled by default once all blockers are resolved.

This does that.