### PR TITLE
CF: Use the original request to pass through headers to origin request.

### DIFF
--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -85,7 +85,7 @@ async function handleRequest(event, config) {
     }
   }
 
-  const response = await fetch(url.href, request);
+  const response = await fetch(url, request);
   const clonedResponse = response.clone();
   const {headers, status, statusText} = response;
 

--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -85,9 +85,7 @@ async function handleRequest(event, config) {
     }
   }
 
-  const response = await fetch(url.toString(), {
-    cf: {minify: {html: true}},
-  });
+  const response = await fetch(url.href, request);
   const clonedResponse = response.clone();
   const {headers, status, statusText} = response;
 


### PR DESCRIPTION
This change is to pass in the original `request` object to the original fetch. This is so that headers that are present on the original request are passed through to the origin request.
Cloudflare adds a headers that are often used by origin request, so this is needed.