### PR TITLE
move imageOptimizer assignment before config.optmizer

### DIFF
--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -238,6 +238,7 @@ function getOptimizer(config) {
   }
   const imageOptimizer = (src, width) => `/cdn-cgi/image/width=${width},f=auto/${src}`;
   return AmpOptimizer.create({
+    imageOptimizer: config.enableCloudflareImageOptimization ? imageOptimizer : undefined,
     ...(config.optimizer || {}),
     minify: false,
     cache: false,
@@ -251,7 +252,6 @@ function getOptimizer(config) {
         },
       }),
     transformations: AmpOptimizer.TRANSFORMATIONS_MINIMAL,
-    imageOptimizer: config.enableCloudflareImageOptimization ? imageOptimizer : undefined,
   });
 }
 


### PR DESCRIPTION
..to allow overriding of the imageOptimizer function.
We like to use a custom imageOptimizer so we can exclude SVG images in `img` tags using our own custom logic. SVG images are not accepted on Cloudflare image resize optimisation. 