### PR TITLE
CI: switch to pull_request from pull_request_target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request_target, push]
+on: [pull_request, push]
 
 jobs:
   test:

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -106,6 +106,7 @@ describe('handleEvent', () => {
   });
 
   it('Should passthrough request to origin in request interceptor mode', async () => {
+    throw new Error('Please fail.');
     const input = `<html amp><body></body></html>`;
     global.fetch.mockReturnValue(getResponse(input));
     await getOutput('http://test.com');

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -106,7 +106,6 @@ describe('handleEvent', () => {
   });
 
   it('Should passthrough request to origin in request interceptor mode', async () => {
-    throw new Error('Please fail.');
     const input = `<html amp><body></body></html>`;
     global.fetch.mockReturnValue(getResponse(input));
     await getOutput('http://test.com');


### PR DESCRIPTION
**summary**
Having the CI action execute on the `pull_request_target` hook was resulting in the tested SHA to [always be main](https://github.com/actions/checkout/issues/486#issue-869251025). By switching to `pull_request`, the correct merge commit of the PR's branch is now chosen instead. You can confirm this by checking the logs of the GH Action before/after.

**fixed screenshot**
![Screen Shot 2021-04-28 at 10 03 02 AM](https://user-images.githubusercontent.com/4656974/116417113-fb0bee80-a808-11eb-8c20-33cbe7e80c8c.png)
