### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org
-      - name: clean
-        run: npx lerna clean --yes
       - name: install
         run: npx lerna bootstrap --hoist
-      - name: build
-        run: npm run build
       - name: test
         run: npm test


### PR DESCRIPTION
- clean should no longer be needed, as caching was not the problem
  causing the CI to fail.
- don't run build twice as it's already run as part of test