### PR TITLE
Add SSR support for fluid layout

### DIFF
--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -81,9 +81,6 @@ function apply(layout, width, height, node) {
       // Do nothing here.
       break;
     case 'fluid':
-      if (width.isSet) {
-        styles = `width:${width.numeral}${width.unit};`;
-      }
       styles += 'height:0;';
       addClass(node, 'i-amphtml-layout-awaiting-size');
       break;

--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -81,7 +81,7 @@ function apply(layout, width, height, node) {
       // Do nothing here.
       break;
     case 'fluid':
-      styles += 'height:0;';
+      styles += 'width:100%;height:0px;';
       addClass(node, 'i-amphtml-layout-awaiting-size');
       break;
     case 'flex-item':

--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -36,6 +36,7 @@ const SUPPORTED_LAYOUTS = [
   'container',
   'fill',
   'flex-item',
+  'fluid',
   'intrinsic',
 ];
 
@@ -78,6 +79,13 @@ function apply(layout, width, height, node) {
     case 'fill':
     case 'container':
       // Do nothing here.
+      break;
+    case 'fluid':
+      if (width.isSet) {
+        styles = `width:${width.numeral}${width.unit};`;
+      }
+      styles += 'height:0;';
+      addClass(node, 'i-amphtml-layout-awaiting-size');
       break;
     case 'flex-item':
       if (width.isSet) {

--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -81,7 +81,7 @@ function apply(layout, width, height, node) {
       // Do nothing here.
       break;
     case 'fluid':
-      styles += 'width:100%;height:0px;';
+      styles += 'width:100%;height:0;';
       addClass(node, 'i-amphtml-layout-awaiting-size');
       break;
     case 'flex-item':

--- a/packages/optimizer/lib/transformers/ApplyLayout.js
+++ b/packages/optimizer/lib/transformers/ApplyLayout.js
@@ -81,7 +81,7 @@ function apply(layout, width, height, node) {
       // Do nothing here.
       break;
     case 'fluid':
-      styles += 'width:100%;height:0;';
+      styles = 'width:100%;height:0;';
       addClass(node, 'i-amphtml-layout-awaiting-size');
       break;
     case 'flex-item':

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_fluid/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_fluid/expected_output.html
@@ -1,0 +1,7 @@
+<html ⚡ i-amphtml-layout i-amphtml-no-boilerplate>
+<head><style amp-runtime></style>
+</head>
+<body>
+  <amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid" class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" style="width:100%;height:0;" i-amphtml-layout="fluid"></amp-ad>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_fluid/input.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_layout_fluid/input.html
@@ -1,0 +1,6 @@
+<html ⚡>
+  <head></head>
+  <body>
+    <amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid"></amp-ad>
+  </body>
+</html>


### PR DESCRIPTION
The use of the `fluid` layout currently blocks server-side rendering since it is not among the `SUPPORTED_LAYOUTS`:

https://github.com/ampproject/amp-toolbox/blob/3ec7bd40f34adbc8be66f951edfa6d91d5794c01/packages/optimizer/lib/transformers/ApplyLayout.js#L30-L40

The `fluid` layout is not ideal because it inherently involves a layout shift since its dimensions get determined at runtime, and it will not get rendered when it is initially in the viewport (per [docs](https://github.com/ampproject/amphtml/blob/main/extensions/amp-ad-network-doubleclick-impl/fluid.md)). Nevertheless, when this layout is required it would be preferable for it to not prevent other parts of the page from benefiting from SSR. 

Implementation provided by @jridgewell. 

Merging this PR is blocked by the AMP validator being updated, specifically to modify [`validateSsrLayout()`](https://github.com/ampproject/amphtml/blob/f2a49b8efa4ecb0cd1dd273977799299a9e1f816/validator/js/engine/validator.js#L4436-L4441) as follows:

```diff
      const validInternalClasses = Object.create(null);
      validInternalClasses[getLayoutClass(layout)] = 0;
      if (isLayoutSizeDefined(layout)) {
        // i-amphtml-layout-size-defined
        validInternalClasses[getLayoutSizeDefinedClass()] = 0;
      }
+     if ('fluid' === layout) {
+       validInternalClasses['i-amphtml-layout-awaiting-size'] = 0;
+     }
```

- [x] Add tests.
- [x] Verify validator updated and deployed.

cf. b/184254585