### PR TITLE
Make ESM config consistent

### DIFF
--- a/packages/optimizer/lib/transformers/AmpBoilerplateErrorHandler.js
+++ b/packages/optimizer/lib/transformers/AmpBoilerplateErrorHandler.js
@@ -59,7 +59,7 @@ class AmpBoilerplateErrorHandler {
     }
 
     const errorHandler = createElement('script', {'amp-onerror': ''});
-    if (params.esmModuleEnabled) {
+    if (params.esmModulesEnabled) {
       insertText(errorHandler, ERROR_HANDLER_MODULE);
     } else {
       insertText(errorHandler, ERROR_HANDLER_NOMODULE);

--- a/packages/optimizer/spec/transformers/valid/AmpBoilerplateErrorHandler/adds_error_handler_when_boilerplate_present_esm_disabled/input.html
+++ b/packages/optimizer/spec/transformers/valid/AmpBoilerplateErrorHandler/adds_error_handler_when_boilerplate_present_esm_disabled/input.html
@@ -1,6 +1,6 @@
 <!--
 {
-  "esmModuleEnabled": false
+  "esmModulesEnabled": false
 }
 -->
 <!doctype html>

--- a/packages/optimizer/spec/transformers/valid/AmpBoilerplateErrorHandler/adds_error_handler_when_boilerplate_present_esm_enabled/input.html
+++ b/packages/optimizer/spec/transformers/valid/AmpBoilerplateErrorHandler/adds_error_handler_when_boilerplate_present_esm_enabled/input.html
@@ -1,6 +1,6 @@
 <!--
 {
-  "esmModuleEnabled": true
+  "esmModulesEnabled": true
 }
 -->
 <!doctype html>


### PR DESCRIPTION
There are two ESM config settings floating around now: `esmModulesEnabled` (which was used from the beginning) and `esmModuleEnabled` (which was introduced in a recent PR re. the boilerplate error handler).

This PR makes the config consistent again by using the first version across the code.