### PR TITLE
fix docker image: transform environment variable values to boolean when possible

### DIFF
--- a/packages/optimizer-docker/utils.js
+++ b/packages/optimizer-docker/utils.js
@@ -4,6 +4,10 @@ function objectFromEntries(arr) {
   return Object.assign({}, ...Array.from(arr, ([k, v]) => ({[k]: v})));
 }
 
+function toBooleanIfPossible(value) {
+  return value === 'true' ? true : value === 'false' ? false : value;
+}
+
 /*
  * Get the static options to pass AMP Optimizer on initialization.
  * All received environment variables prefixed with `AMP_OPTIMIZER_`
@@ -14,7 +18,7 @@ function getStaticOptions(env = process.env) {
     .filter((envVar) => envVar.startsWith('AMP_OPTIMIZER_'))
     .map((envVar) => {
       const optimizerFlag = snakeToCamel(envVar.substring('AMP_OPTIMIZER_'.length));
-      return [optimizerFlag, env[envVar]];
+      return [optimizerFlag, toBooleanIfPossible(env[envVar])];
     });
   return objectFromEntries(optionEntries);
 }


### PR DESCRIPTION
Hello, 

Here is a fix for the docker image and its environment variables handling.

As the variables are strings, the checks in the optimizer fail when they are comparing 'true' with true.

The fix transform the string to a boolean value when possible.

This fixes the following command: 

```
docker run -p 3000:3000 -e AMP_OPTIMIZER_MARKDOWN=false -e AMP_OPTIMIZER_SEPARATE_KEYFRAMES=false ampproject/toolbox-optimizer
```


Let me know
