### PR TITLE
Bail early in `SeparateKeyframes` transformer

### DIFF
--- a/packages/optimizer/lib/transformers/SeparateKeyframes.js
+++ b/packages/optimizer/lib/transformers/SeparateKeyframes.js
@@ -43,8 +43,12 @@ class SeparateKeyframes {
     this.log_ = config.log.tag('SeparateKeyframes');
     this.minify = config.minify !== false;
     this.enabled = !!config.separateKeyframes;
+
+    if (!this.enabled) {
+      return;
+    }
+
     if (
-      this.enabled &&
       (!isDependencyInstalled('postcss') ||
         !isDependencyInstalled('postcss-safe-parser') ||
         !isDependencyInstalled('cssnano-simple'))


### PR DESCRIPTION
Don't warn about missing dependencies if the transformer was disabled via the config anyway.

Fixes #1276