### PR TITLE
Add support for Opaque redirects

### DIFF
--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -89,7 +89,9 @@ async function handleRequest(event, config) {
 
   const response = await fetch(request, { redirect: 'manual' });
 
-  if (response.type === 'opaque-redirect') {
+
+  // Redirect based statuses should be returned
+  if (response.status >= 300 && response.status <= 399) {
     return response;
   }
 

--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -298,7 +298,7 @@ function isRedirectResponse(response) {
  * @param {!ConfigDef} config
  * @description Rewrites the location header if the request is coming from the proxied origin, designed to work with
  */
-function rewriteLocationHeaderIfRequired(response, config) {
+function maybeRewriteRedirectHeader(response, config) {
   const locationHeader =
     response.headers.get('location') ||
     response.headers.get('Location') ||

--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -75,7 +75,7 @@ async function handleRequest(event, config) {
 
   // Immediately return if not GET.
   if (request.method !== 'GET') {
-    return fetch(request, {mode: 'redirect'});
+    return fetch(request, { redirect: 'manual' });
   }
 
   if (config.enableKVCache) {
@@ -87,7 +87,7 @@ async function handleRequest(event, config) {
     }
   }
 
-  const response = await fetch(request, {mode: 'redirect'});
+  const response = await fetch(request, { redirect: 'manual' });
 
   if (response.type === 'opaque-redirect') {
     return response;

--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -75,7 +75,7 @@ async function handleRequest(event, config) {
 
   // Immediately return if not GET.
   if (request.method !== 'GET') {
-    return fetch(request, { redirect: 'manual' });
+    return fetch(request, {redirect: 'manual'});
   }
 
   if (config.enableKVCache) {
@@ -87,8 +87,7 @@ async function handleRequest(event, config) {
     }
   }
 
-  const response = await fetch(request, { redirect: 'manual' });
-
+  const response = await fetch(request, {redirect: 'manual'});
 
   // Redirect based statuses should be returned
   if (response.status >= 300 && response.status <= 399) {

--- a/packages/cloudflare-optimizer-scripts/src/index.js
+++ b/packages/cloudflare-optimizer-scripts/src/index.js
@@ -66,14 +66,16 @@ async function handleRequest(event, config) {
 
   let request = event.request;
   const url = new URL(request.url);
+
   if (isReverseProxy(config)) {
     url.hostname = config.proxy.origin;
   }
+
   request = new Request(url.toString(), request);
 
   // Immediately return if not GET.
   if (request.method !== 'GET') {
-    return fetch(request);
+    return fetch(request, {mode: 'redirect'});
   }
 
   if (config.enableKVCache) {
@@ -85,7 +87,12 @@ async function handleRequest(event, config) {
     }
   }
 
-  const response = await fetch(request);
+  const response = await fetch(request, {mode: 'redirect'});
+
+  if (response.type === 'opaque-redirect') {
+    return response;
+  }
+
   const clonedResponse = response.clone();
   const {headers, status, statusText} = response;
 

--- a/packages/cloudflare-optimizer-scripts/test/builtins.js
+++ b/packages/cloudflare-optimizer-scripts/test/builtins.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 class Response {
-  constructor(text, {headers, status, statusText, type}) {
-    this.type = type;
+  constructor(text, {headers, status, statusText}) {
     this.syncText = text;
     this.text = () => Promise.resolve(text);
     this.headers = headers;
@@ -27,8 +26,7 @@ class Response {
     return new Response(this.syncText, {
       headers: this.headers,
       status: this.status,
-      statusText: this.statusText,
-      type: this.type,
+      statusText: this.statusText
     });
   }
 }

--- a/packages/cloudflare-optimizer-scripts/test/builtins.js
+++ b/packages/cloudflare-optimizer-scripts/test/builtins.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 class Response {
-  constructor(text, {headers, status, statusText}) {
+  constructor(text, {headers, status, statusText, type}) {
+    this.type = type;
     this.syncText = text;
     this.text = () => Promise.resolve(text);
     this.headers = headers;
@@ -27,6 +28,7 @@ class Response {
       headers: this.headers,
       status: this.status,
       statusText: this.statusText,
+      type: this.type,
     });
   }
 }

--- a/packages/cloudflare-optimizer-scripts/test/builtins.js
+++ b/packages/cloudflare-optimizer-scripts/test/builtins.js
@@ -45,4 +45,6 @@ class HTMLRewriter {
   }
 }
 
-module.exports = {Response, HTMLRewriter, Request};
+class Headers extends Map {}
+
+module.exports = {Response, HTMLRewriter, Request, Headers};

--- a/packages/cloudflare-optimizer-scripts/test/builtins.js
+++ b/packages/cloudflare-optimizer-scripts/test/builtins.js
@@ -26,7 +26,7 @@ class Response {
     return new Response(this.syncText, {
       headers: this.headers,
       status: this.status,
-      statusText: this.statusText
+      statusText: this.statusText,
     });
   }
 }

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -145,7 +145,6 @@ describe('handleEvent', () => {
 
     handleEvent(event, defaultConfig);
     expect(await event.respondWith.mock.calls[0][0]).toBe(mockedResponse);
-    expect(event.respondWith).toHaveBeenCalledTimes(1);
   });
 
   it('should rewrite location header for redirects to origin in proxy mode', async () => {

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -128,7 +128,7 @@ describe('handleEvent', () => {
     expect(output).toBe(`transformed-${input}`);
   });
 
-  it('should handle redirects opaquely', async () => {
+  it('should passthrough opaque redirects unmodified', async () => {
     const mockedResponse = new Response('', {
       status: 302,
       statusText: '',

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -105,7 +105,7 @@ describe('handleEvent', () => {
     expect(output).toBe(`transformed-${input}`);
   });
 
-  it('should follow redirects opaquely', async () => {
+  it('should handle redirects opaquely', async () => {
     const mockedResponse = new Response('', {
       status: 302,
       statusText: '',

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- jest.mock('@ampproject/toolbox-optimizer', () => {
+jest.mock('@ampproject/toolbox-optimizer', () => {
   const transformHtml = jest.fn();
   return {
     create: jest.fn(() => ({transformHtml})),

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -122,7 +122,7 @@ describe('handleEvent', () => {
     handleEvent(event, defaultConfig);
 
     expect(global.fetch).toBeCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith(event.request, {mode: 'redirect'});
+    expect(global.fetch).toHaveBeenCalledWith(event.request, {redirect: 'manual'});
 
     expect(await event.respondWith.mock.calls[0][0]).toBe(mockedResponse);
     expect(event.respondWith).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe('handleEvent', () => {
     await getOutput('http://test.com');
     expect(global.fetch).toBeCalledWith(
       {url: 'http://test.com/', method: 'GET'},
-      {mode: 'redirect'}
+      {redirect: 'manual'}
     );
   });
 
@@ -146,7 +146,7 @@ describe('handleEvent', () => {
     await getOutput('http://test.com', config);
     expect(global.fetch).toBeCalledWith(
       {url: 'http://test-origin.com/', method: 'GET'},
-      {mode: 'redirect'}
+      {redirect: 'manual'}
     );
   });
 

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -74,8 +74,7 @@ describe('handleEvent', () => {
   it('should rewrite Location header for Redirect in response to Non-Get Requests (Proxy Mode)', async () => {
     const config = {proxy: {origin: 'test-origin.com', worker: 'test.com'}};
 
-    const originalHeaders = new Headers();
-    originalHeaders.set('Location', 'https://test-origin.com/abc');
+    const originalHeaders = new Headers([['location', 'https://test-origin.com/abc']]);
 
     const originResponse = new Response(undefined, {
       status: 301,

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-jest.mock('@ampproject/toolbox-optimizer', () => {
+ jest.mock('@ampproject/toolbox-optimizer', () => {
   const transformHtml = jest.fn();
   return {
     create: jest.fn(() => ({transformHtml})),
@@ -107,8 +107,7 @@ describe('handleEvent', () => {
 
   it('should follow redirects opaquely', async () => {
     const mockedResponse = new Response('', {
-      type: 'opaque-redirect',
-      status: 0,
+      status: 302,
       statusText: '',
     });
 

--- a/packages/cloudflare-optimizer-scripts/test/index.test.js
+++ b/packages/cloudflare-optimizer-scripts/test/index.test.js
@@ -117,12 +117,9 @@ describe('handleEvent', () => {
       passThroughOnException: jest.fn(),
     };
 
-    global.fetch.mockReturnValue(mockedResponse);
+    global.fetch.mockImplementation(() => Promise.resolve(mockedResponse));
+
     handleEvent(event, defaultConfig);
-
-    expect(global.fetch).toBeCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith(event.request, {redirect: 'manual'});
-
     expect(await event.respondWith.mock.calls[0][0]).toBe(mockedResponse);
     expect(event.respondWith).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
This PR adds support for opaque redirects in @ampproject/cloudflare-optimizer-scripts

### The Problem

If the origin server serves a redirect the `fetch` script automatically follows the redirect and afterwards AMP manipulates the body, leaving no opportunity for there to be a browser navigation based on the redirect status code. 

This is a further concern, when there are Cross Origin navigations present based on the redirects.

### The Solution

~I have added support for fetch's opaque redirect mode which happens to be  the Cloudflare's default mode for the original incoming requests object as well. However, these are overridden and there's no current support for such redirects in Cloudflare.~


~This will let the browser decide what to do with the redirects and will not interrupt the navigation flow.~



The code in PR explicitly makes sure that redirect mode is manual and redirect based status codes are relegated back to browser.

