### PR TITLE
Implement SSR for amp-audio extension

### DIFF
--- a/packages/optimizer/lib/transformers/ServerSideRendering.js
+++ b/packages/optimizer/lib/transformers/ServerSideRendering.js
@@ -20,6 +20,7 @@ const {
   remove,
   createElement,
   insertBefore,
+  insertAfter,
   nextNode,
   firstChildByTag,
 } = require('../NodeUtils');
@@ -81,12 +82,9 @@ class ServerSideRendering {
         this.log_.debug('cannot remove boilerplate: amp-experiment');
       }
 
-      // amp-audio requires knowing the dimensions of the browser. Do not
-      // remove the boilerplate or apply layout if amp-audio is present in the
-      // document.
+      // Server-side rendering of an amp-audio element.
       if (node.tagName === 'amp-audio') {
-        canRemoveBoilerplate = false;
-        this.log_.debug('cannot remove boilerplate: amp-audio');
+        this.ssrAmpAudio(node);
         continue;
       }
 
@@ -210,6 +208,21 @@ class ServerSideRendering {
     } else {
       return nextNode(node);
     }
+  }
+
+  ssrAmpAudio(node) {
+    // Check if we already have a SSR-ed audio element.
+    for (const child of node.children || []) {
+      if (child.tagName === 'audio') {
+        return;
+      }
+    }
+
+    const audio = createElement('audio', {
+      controls: '',
+    });
+
+    insertAfter(node, audio);
   }
 }
 

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_transform_amp_audio/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_transform_amp_audio/expected_output.html
@@ -1,7 +1,0 @@
-<html ⚡ i-amphtml-layout>
-<head><style amp-runtime></style>
-</head>
-<body>
-  <amp-audio></amp-audio>
-</body>
-</html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_transform_amp_audio/input.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/does_not_transform_amp_audio/input.html
@@ -1,6 +1,0 @@
-<html ⚡>
-  <head></head>
-  <body>
-    <amp-audio></amp-audio>
-  </body>
-</html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/expected_output.html
@@ -1,0 +1,12 @@
+<html ⚡ i-amphtml-layout i-amphtml-no-boilerplate>
+<head><style amp-runtime></style>
+</head>
+<body>
+  <amp-audio><audio controls></audio></amp-audio>
+  <amp-audio src="http://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>
+  <amp-audio src="http://example.com/audio.mp3" width="300">
+    <div fallback>Your browser doesn’t support HTML5 audio</div>
+    <audio controls src="http://example.com/audio.mp3"></audio>
+  </amp-audio>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/expected_output.html
@@ -3,10 +3,10 @@
 </head>
 <body>
   <amp-audio><audio controls></audio></amp-audio>
-  <amp-audio src="http://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>
-  <amp-audio src="http://example.com/audio.mp3" width="300">
+  <amp-audio src="https://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>
+  <amp-audio src="https://example.com/audio.mp3" width="300">
     <div fallback>Your browser doesn’t support HTML5 audio</div>
-    <audio controls src="http://example.com/audio.mp3"></audio>
+    <audio controls></audio>
   </amp-audio>
 </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/input.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/input.html
@@ -2,10 +2,10 @@
   <head></head>
   <body>
     <amp-audio></amp-audio>
-    <amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>
-    <amp-audio src="http://example.com/audio.mp3" width="300">
+    <amp-audio src="https://example.com/audio.mp3" width="300"></amp-audio>
+    <amp-audio src="https://example.com/audio.mp3" width="300">
       <div fallback>Your browser doesn’t support HTML5 audio</div>
-      <audio controls src="http://example.com/audio.mp3"></audio>
+      <audio controls></audio>
     </amp-audio>
   </body>
 </html>

--- a/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/input.html
+++ b/packages/optimizer/spec/transformers/valid/ServerSideRendering/transforms_amp_audio/input.html
@@ -1,0 +1,11 @@
+<html ⚡>
+  <head></head>
+  <body>
+    <amp-audio></amp-audio>
+    <amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>
+    <amp-audio src="http://example.com/audio.mp3" width="300">
+      <div fallback>Your browser doesn’t support HTML5 audio</div>
+      <audio controls src="http://example.com/audio.mp3"></audio>
+    </amp-audio>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds the SSR support for amp-audio extension. It simply adds <audio controls></audio> element if amp-audio extension is present.

Related to https://github.com/ampproject/amp-toolbox-php/pull/523 and https://github.com/ampproject/amp-toolbox-php/issues/518.