### PR TITLE
amp optimizer to support ampjs.org (not enabled as default)

### DIFF
--- a/packages/optimizer/lib/AmpConstants.js
+++ b/packages/optimizer/lib/AmpConstants.js
@@ -21,7 +21,8 @@ const AMP_STORY_DVH_POLYFILL_ATTR = 'amp-story-dvh-polyfill';
 
 module.exports = {
   AMP_TAGS: ['amp', '⚡', '⚡4ads', 'amp4ads', '⚡4email', 'amp4email'],
-  AMP_CACHE_HOST: 'https://cdn.ampproject.org',
+  AMP_CACHE_HOSTS: ['https://cdn.ampproject.org', 'https://ampjs.org'],
+  DEFAULT_AMP_CACHE_HOST: 'https://cdn.ampproject.org',
   AMP_VALIDATION_RULES_URL: 'https://cdn.ampproject.org/v0/validator.json',
   AMP_FORMATS: ['AMP', 'AMP4EMAIL', 'AMP4ADS'],
   AMP_RUNTIME_CSS_PATH: '/v0.css',

--- a/packages/optimizer/lib/RuntimeHostHelper.js
+++ b/packages/optimizer/lib/RuntimeHostHelper.js
@@ -15,10 +15,10 @@
  */
 'use strict';
 
-const {AMP_CACHE_HOST, appendRuntimeVersion} = require('./AmpConstants.js');
+const {DEFAULT_AMP_CACHE_HOST, appendRuntimeVersion} = require('./AmpConstants.js');
 
 function calculateHost({
-  ampUrlPrefix = AMP_CACHE_HOST,
+  ampUrlPrefix = DEFAULT_AMP_CACHE_HOST,
   ampRuntimeVersion,
   lts = false,
   rtv = false,

--- a/packages/optimizer/lib/transformers/AddMandatoryTags.js
+++ b/packages/optimizer/lib/transformers/AddMandatoryTags.js
@@ -24,116 +24,10 @@ const {
   createElement,
   firstChildByTag,
 } = require('../NodeUtils');
-const {AMP_FORMATS, AMP_TAGS} = require('../AmpConstants');
+const {AMP_FORMATS, AMP_TAGS, DEFAULT_AMP_CACHE_HOST} = require('../AmpConstants');
 
 const DEFAULT_FORMAT = 'AMP';
 const AUTO_GENERATED_MARKER = 'data-auto';
-
-const BOILERPLATES = {
-  AMP: [
-    {
-      matcher: {
-        tagName: 'meta',
-        attribs: {
-          charset: 'utf-8',
-        },
-      },
-      node: {
-        tagName: 'meta',
-        attribs: {
-          charset: 'utf-8',
-        },
-      },
-    },
-    {
-      matcher: {
-        tagName: 'meta',
-        attribs: {
-          name: 'viewport',
-        },
-      },
-      node: {
-        tagName: 'meta',
-        attribs: {
-          name: 'viewport',
-          content: 'width=device-width,minimum-scale=1,initial-scale=1',
-        },
-      },
-    },
-    {
-      matcher: {
-        tagName: 'noscript',
-      },
-      node: {
-        tagName: 'noscript',
-        children: [
-          {
-            tagName: 'style',
-            attribs: {
-              'amp-boilerplate': '',
-            },
-            // eslint-disable-next-line max-len
-            text:
-              'body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}',
-          },
-        ],
-      },
-    },
-    {
-      matcher: {
-        tagName: 'style',
-        attribs: {
-          'amp-boilerplate': '',
-        },
-      },
-      node: {
-        tagName: 'style',
-        attribs: {
-          'amp-boilerplate': '',
-        },
-        // eslint-disable-next-line max-len
-        text:
-          'body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}',
-      },
-    },
-    {
-      matcher: {
-        tagName: 'script',
-        attribs: {
-          src: /^https:\/\/.+\/v0\.js$/,
-        },
-      },
-      node: {
-        tagName: 'script',
-        attribs: {
-          async: '',
-          src: 'https://cdn.ampproject.org/v0.js',
-        },
-      },
-    },
-    {
-      matcher: {
-        tagName: 'link',
-        attribs: {
-          rel: 'canonical',
-        },
-      },
-      node: {
-        tagName: 'link',
-        attribs: {
-          rel: 'canonical',
-          href: (params, log) => {
-            if (!params.canonical) {
-              log.warn('No canonical param is given. Setting canonical href to `.`');
-              params.canonical = '.';
-            }
-            return params.canonical;
-          },
-        },
-      },
-    },
-  ],
-};
 
 /**
  * AddMandatoryTags - this transformer will automatically add all missing tags required by a valid AMP document.
@@ -164,8 +58,114 @@ class AddMandatoryTags {
       return;
     }
 
+    const boilerplates = {
+      AMP: [
+        {
+          matcher: {
+            tagName: 'meta',
+            attribs: {
+              charset: 'utf-8',
+            },
+          },
+          node: {
+            tagName: 'meta',
+            attribs: {
+              charset: 'utf-8',
+            },
+          },
+        },
+        {
+          matcher: {
+            tagName: 'meta',
+            attribs: {
+              name: 'viewport',
+            },
+          },
+          node: {
+            tagName: 'meta',
+            attribs: {
+              name: 'viewport',
+              content: 'width=device-width,minimum-scale=1,initial-scale=1',
+            },
+          },
+        },
+        {
+          matcher: {
+            tagName: 'noscript',
+          },
+          node: {
+            tagName: 'noscript',
+            children: [
+              {
+                tagName: 'style',
+                attribs: {
+                  'amp-boilerplate': '',
+                },
+                // eslint-disable-next-line max-len
+                text:
+                  'body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}',
+              },
+            ],
+          },
+        },
+        {
+          matcher: {
+            tagName: 'style',
+            attribs: {
+              'amp-boilerplate': '',
+            },
+          },
+          node: {
+            tagName: 'style',
+            attribs: {
+              'amp-boilerplate': '',
+            },
+            // eslint-disable-next-line max-len
+            text:
+              'body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}',
+          },
+        },
+        {
+          matcher: {
+            tagName: 'script',
+            attribs: {
+              src: /^https:\/\/.+\/v0\.js$/,
+            },
+          },
+          node: {
+            tagName: 'script',
+            attribs: {
+              async: '',
+              src: (params.ampUrlPrefix || DEFAULT_AMP_CACHE_HOST) + '/v0.js',
+            },
+          },
+        },
+        {
+          matcher: {
+            tagName: 'link',
+            attribs: {
+              rel: 'canonical',
+            },
+          },
+          node: {
+            tagName: 'link',
+            attribs: {
+              rel: 'canonical',
+              href: (params, log) => {
+                if (!params.canonical) {
+                  log.warn('No canonical param is given. Setting canonical href to `.`');
+                  params.canonical = '.';
+                }
+                return params.canonical;
+              },
+            },
+          },
+        },
+      ],
+    };
+
     // Only supports AMP for websites
-    const boilerplateSpec = BOILERPLATES[this.format];
+    const boilerplateSpec = boilerplates[this.format];
     if (!boilerplateSpec) {
       this.log_.info('Unsupported AMP format', this.format);
       return;

--- a/packages/optimizer/lib/transformers/AmpStoryCssTransformer.js
+++ b/packages/optimizer/lib/transformers/AmpStoryCssTransformer.js
@@ -13,7 +13,7 @@ const {
   firstChildByTag,
   appendChild,
 } = require('../NodeUtils');
-const {AMP_CACHE_HOST} = require('../AmpConstants.js');
+const {DEFAULT_AMP_CACHE_HOST} = require('../AmpConstants.js');
 
 // This string should not be modified, even slightly. This string is strictly
 // checked by the validator.
@@ -139,7 +139,7 @@ function appendAmpStoryCssLink(head) {
     'amp-extension': 'amp-story',
     // We rely on the `RewriteAmpUrls` transformer to modify this to
     // the correct LTS or correct rtv path.
-    'href': `${AMP_CACHE_HOST}/v0/amp-story-1.0.css`,
+    'href': `${DEFAULT_AMP_CACHE_HOST}/v0/amp-story-1.0.css`,
   });
   appendChild(head, ampStoryCssLink);
 }

--- a/packages/optimizer/lib/transformers/AutoExtensionImporter.js
+++ b/packages/optimizer/lib/transformers/AutoExtensionImporter.js
@@ -23,7 +23,7 @@ const {
   hasAttribute,
 } = require('../NodeUtils');
 const {findMetaViewport, findRuntimeScript} = require('../HtmlDomHelper');
-const {AMP_FORMATS, AMP_CACHE_HOST} = require('../AmpConstants');
+const {AMP_FORMATS, DEFAULT_AMP_CACHE_HOST} = require('../AmpConstants');
 
 const BIND_SHORT_FORM_PREFIX = 'bind';
 const AMP_BIND_DATA_ATTRIBUTE_PREFIX = 'data-amp-bind-';
@@ -188,7 +188,7 @@ class AutoExtensionImporter {
     }
 
     // Use cdn.ampproject.org as default, RewriteUrlTransformer will change this in case of self-hosting
-    const host = AMP_CACHE_HOST;
+    const host = DEFAULT_AMP_CACHE_HOST;
     for (const extensionName of extensionsToImport) {
       if (existingImports.has(extensionName)) {
         continue;

--- a/packages/optimizer/lib/transformers/ReorderHeadTransformer.js
+++ b/packages/optimizer/lib/transformers/ReorderHeadTransformer.js
@@ -191,7 +191,7 @@ class HeadNodes {
       rel === 'prefetch' ||
       rel === 'dns-prefetch' ||
       rel === 'preconnect' ||
-      rel == 'modulepreload'
+      rel === 'modulepreload'
     ) {
       this._resourceHintLinks.push(node);
       return;

--- a/packages/optimizer/lib/transformers/RewriteAmpUrls.js
+++ b/packages/optimizer/lib/transformers/RewriteAmpUrls.js
@@ -23,7 +23,7 @@ const {
   insertBefore,
   remove,
 } = require('../NodeUtils');
-const {AMP_CACHE_HOST} = require('../AmpConstants.js');
+const {AMP_CACHE_HOSTS} = require('../AmpConstants.js');
 const {findMetaViewport} = require('../HtmlDomHelper');
 const {calculateHost} = require('../RuntimeHostHelper');
 
@@ -141,13 +141,15 @@ class RewriteAmpUrls {
 
   _usesAmpCacheUrl(url) {
     if (!url) {
-      return;
+      return false;
     }
-    return url.startsWith(AMP_CACHE_HOST);
+    // check if url starts with one of string array
+    return AMP_CACHE_HOSTS.some((host) => url.startsWith(host));
   }
 
   _replaceUrl(url, host) {
-    return host + url.substring(AMP_CACHE_HOST.length);
+    const existingHost = AMP_CACHE_HOSTS.find((ampCacheHost) => url.startsWith(ampCacheHost));
+    return host + url.substring(existingHost.length);
   }
 
   _addEsm(scriptNode, preloadEnabled) {

--- a/packages/optimizer/spec/helpers/validatorInstance.js
+++ b/packages/optimizer/spec/helpers/validatorInstance.js
@@ -6,6 +6,7 @@ let instance = null;
 module.exports = {
   get: () => {
     if (!instance) {
+      console.error('Validator instance created: ' + path.join(__dirname, 'validator.js'));
       instance = validator.getInstance(path.join(__dirname, 'validator.js'));
     }
     return instance;

--- a/packages/optimizer/spec/transformers/valid/AddMandatoryTags/keep-existing-tags-ampjs/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/AddMandatoryTags/keep-existing-tags-ampjs/expected_output.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <title>My AMP Page</title>
+  <link rel="canonical" href="self.html">
+  <script data-auto async src="https://ampjs.org/v0.js"></script>
+  <meta data-auto charset="utf-8">
+  <meta data-auto name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"><noscript data-auto><style data-auto amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style data-auto amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
+</head>
+<body>
+  <h1>hello world</h1>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/AddMandatoryTags/keep-existing-tags-ampjs/input.html
+++ b/packages/optimizer/spec/transformers/valid/AddMandatoryTags/keep-existing-tags-ampjs/input.html
@@ -1,0 +1,10 @@
+<html ⚡>
+<head>
+  <title>My AMP Page</title>
+  <link rel="canonical" href="self.html" />
+  <script data-auto async src="https://ampjs.org/v0.js"></script>
+</head>
+<body>
+  <h1>hello world</h1>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_lts_ampjs/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_lts_ampjs/expected_output.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/lts/v0/amp-experiment-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/lts/v0.js"></script>
+  <link rel="stylesheet" href="https://cdn.ampproject.org/lts/v0.css">
+  <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
+  <link href="https://example.com/favicon.ico" rel="icon">
+  <link rel="preload" href="https://cdn.ampproject.org/lts/v0.js" as="script">
+  <link rel="preload" href="https://cdn.ampproject.org/lts/v0.css" as="style">
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_lts_ampjs/input.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_lts_ampjs/input.html
@@ -1,0 +1,16 @@
+<!--
+{
+  "lts": true
+}
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element=amp-experiment src=https://ampjs.org/v0/amp-experiment-0.1.js></script>
+  <script async src="https://ampjs.org/v0.js"></script>
+  <link rel=stylesheet href=https://ampjs.org/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_preloads_ampjs/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_preloads_ampjs/expected_output.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
+  <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
+  <link href="https://example.com/favicon.ico" rel="icon">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
+</head>
+<body></body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_preloads_ampjs/input.html
+++ b/packages/optimizer/spec/transformers/valid/RewriteAmpUrls/adds_preloads_ampjs/input.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <script async custom-element=amp-experiment src=https://ampjs.org/v0/amp-experiment-0.1.js></script>
+  <script async src="https://ampjs.org/v0.js"></script>
+  <link rel=stylesheet href=https://ampjs.org/v0.css>
+  <link href=https://fonts.googleapis.com/css?foobar rel=stylesheet type=text/css>
+  <link href=https://example.com/favicon.ico rel=icon>
+</head>
+<body></body>
+</html>

--- a/packages/runtime-version/lib/RuntimeVersion.js
+++ b/packages/runtime-version/lib/RuntimeVersion.js
@@ -15,9 +15,10 @@
  */
 'use strict';
 
+const {DEFAULT_AMP_CACHE_HOST} = require('../../optimizer/lib/AmpConstants');
+
 const log = require('@ampproject/toolbox-core').log.tag('AMP Runtime Version');
 
-const AMP_CACHE_HOST = 'https://cdn.ampproject.org';
 const RUNTIME_METADATA_PATH = '/rtv/metadata';
 const VERSION_TXT_PATH = '/version.txt';
 
@@ -96,7 +97,9 @@ class RuntimeVersion {
       releaseType = ReleaseType.lts;
     }
 
-    const host = options.ampUrlPrefix ? options.ampUrlPrefix.replace(/\/$/, '') : AMP_CACHE_HOST;
+    const host = options.ampUrlPrefix
+      ? options.ampUrlPrefix.replace(/\/$/, '')
+      : DEFAULT_AMP_CACHE_HOST;
 
     let rtv = await this.getVersionFromRuntimeMetadata_(host, releaseType);
     if (!rtv && releaseType === ReleaseType.prod) {


### PR DESCRIPTION
This PR will enable the transformer to recognize ampjs.org as valid AMP CDN. However, it does not automatically change the CDN to ampjs.org. The default is still cdn.ampproject.org. To use ampjs.org, can override with `ampUrlPrefix` param.

Adds test cases to ensure script tags pointing to either CDN get rewritten to the CDN configured.