### PR TITLE
[toolbox-optimizer] Fix crash if `<template>` is the very last element

### DIFF
--- a/packages/optimizer/lib/transformers/OptimizeAmpBind.js
+++ b/packages/optimizer/lib/transformers/OptimizeAmpBind.js
@@ -43,7 +43,11 @@ class OptimizeAmpBind {
     for (let node = html; node !== null; node = nextNode(node)) {
       if (isTemplate(node)) {
         node = skipNodeAndChildren(node);
-        continue;
+        if (node === null) {
+          break;
+        } else {
+          continue;
+        }
       }
 
       const {attribs} = node;

--- a/packages/optimizer/spec/transformers/valid/OptimizeAmpBind/template_last/expected_output.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeAmpBind/template_last/expected_output.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html ⚡ i-amphtml-binding>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+  <div data-amp-bind-text="foo" i-amphtml-binding>Hello, AMP world.</div>
+  <template id="my-template">Must be the very last element. Whitespace after closing tag would alter the test.</template>
+</body>
+</html>

--- a/packages/optimizer/spec/transformers/valid/OptimizeAmpBind/template_last/input.html
+++ b/packages/optimizer/spec/transformers/valid/OptimizeAmpBind/template_last/input.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+    <div data-amp-bind-text="foo">Hello, AMP world.</div>
+    <template id="my-template">Must be the very last element. Whitespace after closing tag would alter the test.</template></body></html>


### PR DESCRIPTION
Fixes `TypeError: Cannot read properties of null (reading 'firstChild')` if a `<template>` was the last element.

Existing tests didn't catch this since `<template>` was followed by some whitespace. However, when we manually advance the `node`, we need to check the enter condition of the loop again since `nextNode` does not accept a nullable node.