### PR TITLE
fix: run puppeteer tests correctly on Ubuntu 23.10+ OS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Disable AppArmor on Ubuntu for puppeteer Chrome test
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Use node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/packages/optimizer/lib/transformers/Markdown.js
+++ b/packages/optimizer/lib/transformers/Markdown.js
@@ -72,7 +72,7 @@ class Markdown {
       if (node.tagName === 'img') {
         promises.push(this.transformImg(node, params));
       }
-      if(node.tagName === 'picture') {
+      if (node.tagName === 'picture') {
         promises.push(this.transformPicture(node, params));
       }
       node = tmpNode;

--- a/packages/optimizer/spec/end-to-end/EndToEndSpec.js
+++ b/packages/optimizer/spec/end-to-end/EndToEndSpec.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-require('fetch-mock');
 const createSpec = require('../helpers/TransformerRunner.js');
 const log = require('../../lib/log.js');
 const {


### PR DESCRIPTION
## Summary

Restore Puppeteer Chrome tests on Ubuntu 23.10+ by disabling AppArmor in CI and clean up test imports
In addition

Bug Fixes:
- Fix Puppeteer test failures on Ubuntu-latest by disabling AppArmor restrictions

CI:
- Add CI step to disable AppArmor on Ubuntu for Puppeteer Chrome tests

Tests:
- Remove redundant fetch-mock import from end-to-end spec

## How to verify your codes work?

I have tested it on my GitHub Actions.
Furthermore, run lint.

```bash
npm run lint:fix
```

x-ref: [Issues with AppArmor on Ubuntu](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#issues-with-apparmor-on-ubuntu)